### PR TITLE
Bump gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -118,6 +118,6 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,6 @@ jobs:
       - name: Build package
         run: uv build
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true


### PR DESCRIPTION
## Why

The [v0.0.30 publish run](https://github.com/CelestoAI/SmolVM/actions/runs/32664523619/job/97255760163) failed with:

```
Checking dist/smolvm-0.0.30-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`uv build` now produces wheels declaring core packaging **Metadata-Version 2.5** (verified locally against this checkout), and the previously pinned `gh-action-pypi-publish` commit bundles a Twine too old to recognize it.

## What

Pin `pypa/gh-action-pypi-publish` to `dc37677b` (**v1.14.2**) in both `publish.yml` and `publish-core.yml`. The [v1.14.2 release notes](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2) call this out directly: it upgrades to Twine v7, which supports uploading sdists and wheels with metadata v2.5.

## After merging

The failed run can't just be re-run — tag workflows execute the workflow file at the tag's commit, which still has the old pin. To publish 0.0.30, re-point the `v0.0.30` tag at the merge commit (or delete and re-push the tag). `skip-existing: true` keeps that safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNp4o3KvfZe64FV5Wnf9rx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package publishing workflow to use a specific, pinned release of the publishing action.
  - Applied the same publishing workflow update across all package release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->