### PR TITLE
Support configurable Firecracker installs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,29 @@ smolvm doctor
 
 `smolvm doctor` reports problems and their recovery steps. Add `--strict` when a warning should fail an automated check.
 
+### Choose where Firecracker is stored
+
+On Linux, Firecracker is the program that starts a sandbox. SmolVM stores it in `~/.smolvm/bin` by default, which works without changing system folders.
+
+Choose another folder for one setup run with:
+
+```bash
+smolvm setup --firecracker-dir "$HOME/.local/bin"
+```
+
+If that folder is not already on `PATH`, set it for future SmolVM commands:
+
+```bash
+export SMOLVM_FIRECRACKER_DIR="$HOME/.local/share/smolvm/bin"
+smolvm setup
+```
+
+This setting changes only the Firecracker location. Images still use `SMOLVM_IMAGE_DIR`, and sandbox state still uses `SMOLVM_DATA_DIR`.
+
+### Fedora Atomic desktops
+
+Silverblue, Bluefin, and other Fedora Atomic systems can use the normal setup command when the required host tools are already installed. SmolVM does not change the rpm-ostree deployment automatically. If a tool is missing, setup prints the exact `rpm-ostree` command and asks you to reboot before retrying.
+
 ### Prepare macOS desktop support
 
 Apple Silicon Mac users can install the separate local desktop runtime:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ smolvm setup --firecracker-dir "$HOME/.local/bin"
 If that folder is not already on `PATH`, set it for future SmolVM commands:
 
 ```bash
-export SMOLVM_FIRECRACKER_DIR="$HOME/.local/share/smolvm/bin"
+export SMOLVM_FIRECRACKER_DIR="$HOME/.local/bin"
 smolvm setup
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,6 +12,14 @@ The CLI creates and manages disposable sandboxes. Run `smolvm COMMAND --help` fo
 | `smolvm update` | Upgrade to the latest stable release. |
 | `smolvm prune` | Remove stale cached images (alias for `smolvm image prune`). |
 
+On Linux, `smolvm setup` stores Firecracker—the program that starts a sandbox—in `~/.smolvm/bin`. Use `--firecracker-dir` to choose another folder for one setup run:
+
+```bash
+smolvm setup --firecracker-dir "$HOME/.local/bin"
+```
+
+Set `SMOLVM_FIRECRACKER_DIR` when future commands also need to find a folder that is not on `PATH`. See [Install SmolVM](../installation.md) for Fedora Atomic and build-machine setup.
+
 ## Work with sandboxes
 
 Run these in the order you need them:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -186,15 +186,15 @@ shell_hint() {
 
 main() {
     printf "\n"
-    printf "%s" "${GREEN}"
+    printf "%b" "${GREEN}"
     cat <<'BANNER'
       ___      _        _          _   ___
      / __|___ | |___ __| |_ ___   /_\ |_ _|
     | (__/ -_)| / -_|_-<  _/ _ \ / _ \ | |
      \___\___||_\___/__/\__\___//_/ \_\___|
 BANNER
-    printf "%s" "${RESET}"
-    printf "    %sSmolVM Installer%s\n" "${BOLD}" "${RESET}"
+    printf "%b" "${RESET}"
+    printf "    %bSmolVM Installer%b\n" "${BOLD}" "${RESET}"
     printf "    One command to give AI agents their own computer.\n\n"
 
     ensure_uv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,8 +27,9 @@
 #   3. Runs `smolvm setup` to configure the host
 #
 # Options (forwarded to `smolvm setup`):
-#   --skip-deps      Skip apt dependency installation (assumes deps are present)
-#   --with-docker    Also install Docker for SSH image support
+#   --skip-deps              Skip operating-system package installation
+#   --with-docker            Also install Docker for SSH image support
+#   --firecracker-dir <dir>  Install Firecracker in a specific folder
 #
 # After installation, the `smolvm` command is available globally.
 
@@ -49,11 +50,35 @@ warn()  { printf "${BOLD}${YELLOW}warning:${RESET} %s\n" "$*"; }
 error() { printf "${BOLD}${RED}error:${RESET} %s\n" "$*" >&2; }
 die()   { error "$@"; exit 1; }
 
-# Collect extra flags to forward to `smolvm setup`
+# Collect extra flags to forward to `smolvm setup`. Remember the Firecracker
+# folder so the final doctor check uses the same location.
 SETUP_ARGS=()
-for arg in "$@"; do
-    SETUP_ARGS+=("$arg")
+FIRECRACKER_DIR_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --firecracker-dir)
+            if [[ $# -lt 2 ]]; then
+                die "--firecracker-dir needs a folder."
+            fi
+            SETUP_ARGS+=("$1" "$2")
+            FIRECRACKER_DIR_ARG="$2"
+            shift 2
+            ;;
+        --firecracker-dir=*)
+            SETUP_ARGS+=("$1")
+            FIRECRACKER_DIR_ARG="${1#*=}"
+            shift
+            ;;
+        *)
+            SETUP_ARGS+=("$1")
+            shift
+            ;;
+    esac
 done
+
+if [[ -n "${FIRECRACKER_DIR_ARG}" ]]; then
+    export SMOLVM_FIRECRACKER_DIR="${FIRECRACKER_DIR_ARG}"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 1 — Ensure uv is available
@@ -67,7 +92,9 @@ find_uv() {
     # 2. Common install locations (not yet on PATH in this session)
     for candidate in "$HOME/.local/bin/uv" "$HOME/.cargo/bin/uv"; do
         if [ -x "$candidate" ]; then
-            export PATH="$(dirname "$candidate"):$PATH"
+            local candidate_dir
+            candidate_dir="$(dirname "$candidate")"
+            export PATH="${candidate_dir}:$PATH"
             return 0
         fi
     done
@@ -127,7 +154,7 @@ install_smolvm() {
 
 run_setup() {
     info "Running smolvm setup …"
-    smolvm setup --skip-deps ${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}
+    smolvm setup --skip-deps "${SETUP_ARGS[@]}"
 }
 
 # ---------------------------------------------------------------------------
@@ -159,15 +186,15 @@ shell_hint() {
 
 main() {
     printf "\n"
-    printf "${GREEN}"
+    printf "%s" "${GREEN}"
     cat <<'BANNER'
       ___      _        _          _   ___
      / __|___ | |___ __| |_ ___   /_\ |_ _|
     | (__/ -_)| / -_|_-<  _/ _ \ / _ \ | |
      \___\___||_\___/__/\__\___//_/ \_\___|
 BANNER
-    printf "${RESET}"
-    printf "    ${BOLD}SmolVM Installer${RESET}\n"
+    printf "%s" "${RESET}"
+    printf "    %sSmolVM Installer%s\n" "${BOLD}" "${RESET}"
     printf "    One command to give AI agents their own computer.\n\n"
 
     ensure_uv

--- a/scripts/internal/configure-runtime-sudoers.sh
+++ b/scripts/internal/configure-runtime-sudoers.sh
@@ -141,7 +141,7 @@ validate_helper_directory() {
 }
 
 validate_helper_file() {
-    if [[ ! -f "${LOOPFS_HELPER_DST}" || ! -x "${LOOPFS_HELPER_DST}" ]]; then
+    if [[ -L "${LOOPFS_HELPER_DST}" || ! -f "${LOOPFS_HELPER_DST}" || ! -x "${LOOPFS_HELPER_DST}" ]]; then
         echo "❌ Runtime helper is missing or not executable: '${LOOPFS_HELPER_DST}'; run 'smolvm setup' to restore it."
         return 1
     fi

--- a/scripts/internal/configure-runtime-sudoers.sh
+++ b/scripts/internal/configure-runtime-sudoers.sh
@@ -24,7 +24,8 @@ CHECK_ONLY=false
 REMOVE=false
 SKIP_RUNTIME_CHECK=false
 LOOPFS_HELPER_SRC="${SCRIPT_DIR}/image-build-loopfs.sh"
-LOOPFS_HELPER_DST="/usr/local/libexec/smolvm-loopfs-helper"
+LOOPFS_HELPER_DIR="/var/lib/smolvm/libexec"
+LOOPFS_HELPER_DST="${LOOPFS_HELPER_DIR}/smolvm-loopfs-helper"
 
 usage() {
     cat <<EOF
@@ -99,19 +100,13 @@ IP_BIN="$(command -v ip || true)"
 NFT_BIN="$(command -v nft || true)"
 SYSCTL_BIN="$(command -v sysctl || true)"
 VISUDO_BIN="$(command -v visudo || true)"
-FIRECRACKER_BIN="$(command -v firecracker || true)"
 INSTALL_BIN="$(command -v install || true)"
-
-if [[ -z "${FIRECRACKER_BIN}" && -x "/usr/local/bin/firecracker" ]]; then
-    FIRECRACKER_BIN="/usr/local/bin/firecracker"
-fi
 
 for item in \
     "ip:${IP_BIN}" \
     "nft:${NFT_BIN}" \
     "sysctl:${SYSCTL_BIN}" \
     "visudo:${VISUDO_BIN}" \
-    "firecracker:${FIRECRACKER_BIN}" \
     "install:${INSTALL_BIN}"
 do
     name="${item%%:*}"
@@ -124,13 +119,52 @@ done
 
 SUDOERS_FILE="/etc/sudoers.d/smolvm-runtime-${RUNTIME_USER}"
 
+validate_helper_directory() {
+    local path
+    local owner
+    local mode
+    for path in /var /var/lib /var/lib/smolvm "${LOOPFS_HELPER_DIR}"; do
+        if [[ -L "${path}" ]]; then
+            echo "❌ Runtime helper folder cannot be a link: '${path}'; remove the link, then run 'smolvm setup' again."
+            return 1
+        fi
+        if [[ ! -e "${path}" ]]; then
+            continue
+        fi
+        owner="$(stat -c %u "${path}")"
+        mode="$(stat -c %a "${path}")"
+        if [[ "${owner}" != "0" ]] || (( (8#${mode} & 8#022) != 0 )); then
+            echo "❌ Runtime helper folder must be controlled by root: '${path}'; run 'sudo chown root:root ${path} && sudo chmod 755 ${path}', then run 'smolvm setup' again."
+            return 1
+        fi
+    done
+}
+
+validate_helper_file() {
+    if [[ ! -f "${LOOPFS_HELPER_DST}" || ! -x "${LOOPFS_HELPER_DST}" ]]; then
+        echo "❌ Runtime helper is missing or not executable: '${LOOPFS_HELPER_DST}'; run 'smolvm setup' to restore it."
+        return 1
+    fi
+    local owner
+    local mode
+    owner="$(stat -c %u "${LOOPFS_HELPER_DST}")"
+    mode="$(stat -c %a "${LOOPFS_HELPER_DST}")"
+    if [[ "${owner}" != "0" ]] || (( (8#${mode} & 8#022) != 0 )); then
+        echo "❌ Runtime helper must be controlled by root: '${LOOPFS_HELPER_DST}'; run 'smolvm setup' to restore it."
+        return 1
+    fi
+}
+
 install_loopfs_helper() {
     if [[ ! -f "${LOOPFS_HELPER_SRC}" ]]; then
-        echo "❌ Required helper script not found: ${LOOPFS_HELPER_SRC}"
+        echo "❌ Runtime helper source is missing: '${LOOPFS_HELPER_SRC}'; reinstall SmolVM, then run 'smolvm setup' again."
         exit 1
     fi
-    mkdir -p "$(dirname "${LOOPFS_HELPER_DST}")"
+    validate_helper_directory
+    "${INSTALL_BIN}" -d -o root -g root -m 0755 /var/lib/smolvm "${LOOPFS_HELPER_DIR}"
+    validate_helper_directory
     "${INSTALL_BIN}" -o root -g root -m 0755 "${LOOPFS_HELPER_SRC}" "${LOOPFS_HELPER_DST}"
+    validate_helper_file
 }
 
 render_sudoers() {
@@ -140,11 +174,10 @@ render_sudoers() {
     # sysctl to a per-tap pattern. Sysctl is widened to match the ip/nft scope.
     cat > "${target_file}" <<EOF
 # Managed by SmolVM (${SCRIPT_NAME}) for user ${RUNTIME_USER}
-# Allows only commands needed by SmolVM runtime networking, Firecracker, and image mount helper.
+# Allows only commands needed by SmolVM networking and the image-build helper.
 Cmnd_Alias SMOLVM_NET_CMDS = ${IP_BIN} *, ${NFT_BIN} *, ${SYSCTL_BIN} *
-Cmnd_Alias SMOLVM_VM_CMDS = ${FIRECRACKER_BIN} *, /bin/kill -9 *, /usr/bin/kill -9 *
 Cmnd_Alias SMOLVM_IMG_CMDS = ${LOOPFS_HELPER_DST} *
-${RUNTIME_USER} ALL=(root) NOPASSWD: SMOLVM_NET_CMDS, SMOLVM_VM_CMDS, SMOLVM_IMG_CMDS
+${RUNTIME_USER} ALL=(root) NOPASSWD: SMOLVM_NET_CMDS, SMOLVM_IMG_CMDS
 EOF
 }
 
@@ -165,9 +198,6 @@ check_runtime_access() {
     fi
     if ! "${runner[@]}" "${SYSCTL_BIN}" net.ipv4.ip_forward >/dev/null 2>&1; then
         failures+=("sysctl")
-    fi
-    if ! "${runner[@]}" "${FIRECRACKER_BIN}" --version >/dev/null 2>&1; then
-        failures+=("firecracker")
     fi
     if ! "${runner[@]}" "${LOOPFS_HELPER_DST}" --help >/dev/null 2>&1; then
         failures+=("image-build-loopfs-helper")
@@ -198,10 +228,8 @@ if [[ "${CHECK_ONLY}" == "true" ]]; then
         exit 1
     fi
     validate_sudoers_file "${SUDOERS_FILE}"
-    if [[ ! -x "${LOOPFS_HELPER_DST}" ]]; then
-        echo "❌ Runtime helper missing or not executable: ${LOOPFS_HELPER_DST}"
-        exit 1
-    fi
+    validate_helper_directory
+    validate_helper_file
     check_runtime_access
     exit 0
 fi

--- a/scripts/internal/install-firecracker.sh
+++ b/scripts/internal/install-firecracker.sh
@@ -141,18 +141,25 @@ if ! id "${runtime_user}" >/dev/null 2>&1; then
     exit 1
 fi
 runtime_group="$(id -gn "${runtime_user}")"
-runtime_home="$(resolve_user_home "${runtime_user}")"
+runtime_home=""
 
 if [[ -n "${FIRECRACKER_DIR_OVERRIDE}" ]]; then
     FIRECRACKER_DIR="${FIRECRACKER_DIR_OVERRIDE}"
 elif [[ -n "${SMOLVM_FIRECRACKER_DIR+x}" ]]; then
     if [[ -z "${SMOLVM_FIRECRACKER_DIR//[[:space:]]/}" ]]; then
-        echo "❌ SMOLVM_FIRECRACKER_DIR is empty; unset it or set it to an absolute folder."
+        echo "❌ SMOLVM_FIRECRACKER_DIR is empty; run 'unset SMOLVM_FIRECRACKER_DIR', then run 'smolvm setup'."
         exit 1
     fi
     FIRECRACKER_DIR="${SMOLVM_FIRECRACKER_DIR}"
 else
+    runtime_home="$(resolve_user_home "${runtime_user}")"
     FIRECRACKER_DIR="${runtime_home}/.smolvm/bin"
+fi
+
+# A configured folder does not require a home lookup, but use one when available
+# so destinations inside the user's home keep that user's ownership.
+if [[ -z "${runtime_home}" ]]; then
+    runtime_home="$(resolve_user_home "${runtime_user}" 2>/dev/null || true)"
 fi
 
 if [[ "${FIRECRACKER_DIR}" != /* ]]; then
@@ -165,8 +172,10 @@ if [[ -e "${FIRECRACKER_DIR}" && ! -d "${FIRECRACKER_DIR}" ]]; then
 fi
 
 user_scoped_dir=false
-if [[ "${FIRECRACKER_DIR}" == "${runtime_home}" || "${FIRECRACKER_DIR}" == "${runtime_home}/"* ]]; then
-    user_scoped_dir=true
+if [[ -n "${runtime_home}" ]]; then
+    if [[ "${FIRECRACKER_DIR}" == "${runtime_home}" || "${FIRECRACKER_DIR}" == "${runtime_home}/"* ]]; then
+        user_scoped_dir=true
+    fi
 fi
 
 if [[ -n "${FC_VERSION_OVERRIDE}" ]]; then

--- a/scripts/internal/install-firecracker.sh
+++ b/scripts/internal/install-firecracker.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# install-firecracker.sh - Internal helper to install Firecracker and Jailer.
+# install-firecracker.sh - Internal helper to install Firecracker.
 # Intended to be called by scripts/system-setup.sh.
 set -euo pipefail
 
@@ -22,18 +22,25 @@ WITH_IMAGES=false
 SKIP_DEPS=false
 REQUIRE_KVM=false
 FC_VERSION_OVERRIDE=""
+FIRECRACKER_DIR_OVERRIDE=""
+RUNTIME_USER_OVERRIDE=""
 
 usage() {
     cat <<EOF_USAGE
-Usage: $(basename "$0") [--with-images] [--skip-deps] [--require-kvm] [--firecracker-version <ver>]
+Usage: $(basename "$0") [options]
+
+Downloads and installs Firecracker without changing operating-system packages
+when --skip-deps is used.
 
 Options:
   --with-images               Download kernel/rootfs images after install
-  --skip-deps                 Skip apt dependency install (requires wget + tar)
-  --require-kvm               Fail if /dev/kvm is missing (default: skip the check
-                              so installs work on bake hosts; runtime/doctor catch it)
+  --skip-deps                 Do not install wget or tar
+  --require-kvm               Fail if /dev/kvm is missing
   --firecracker-version <ver> Pin Firecracker release tag (default: built-in or
                               \$SMOLVM_FIRECRACKER_VERSION / \$FC_VERSION env)
+  --firecracker-dir <dir>     Folder for Firecracker (default:
+                              \$SMOLVM_FIRECRACKER_DIR or ~/.smolvm/bin)
+  --runtime-user <user>       User who will run Firecracker (internal setup option)
   -h, --help                  Show this help
 EOF_USAGE
 }
@@ -50,22 +57,31 @@ while [[ $# -gt 0 ]]; do
             REQUIRE_KVM=true
             ;;
         --firecracker-version)
-            if [[ $# -lt 2 ]]; then
-                echo "❌ --firecracker-version requires a value"
-                usage
-                exit 1
-            fi
-            if [[ -z "$2" || "$2" == -* ]]; then
-                echo "❌ --firecracker-version got an invalid value: '$2'"
-                echo "   Expected a release tag like 'v1.14.1' (no leading dash, not empty)."
+            if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+                echo "❌ --firecracker-version needs a release tag such as 'v1.14.1'."
                 exit 1
             fi
             if [[ ! "$2" =~ ^[A-Za-z0-9._-]+$ ]]; then
-                echo "❌ --firecracker-version contains invalid characters: '$2'"
-                echo "   Allowed: letters, digits, '.', '_', '-' (e.g. 'v1.14.1')."
+                echo "❌ Firecracker version '$2' contains unsupported characters; use a tag such as 'v1.14.1'."
                 exit 1
             fi
             FC_VERSION_OVERRIDE="$2"
+            shift
+            ;;
+        --firecracker-dir)
+            if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+                echo "❌ --firecracker-dir needs a folder; for example, run 'smolvm setup --firecracker-dir \"$HOME/.local/bin\"'."
+                exit 1
+            fi
+            FIRECRACKER_DIR_OVERRIDE="$2"
+            shift
+            ;;
+        --runtime-user)
+            if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+                echo "❌ --runtime-user needs the account that will run SmolVM."
+                exit 1
+            fi
+            RUNTIME_USER_OVERRIDE="$2"
             shift
             ;;
         -h|--help)
@@ -73,35 +89,86 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         *)
-            echo "Unknown argument: $1"
-            usage
+            echo "❌ Unknown option '$1'; run '$(basename "$0") --help' to see supported options."
             exit 1
             ;;
     esac
     shift
 done
 
-SUDO=""
-if [[ ${EUID} -ne 0 ]]; then
-    if command -v sudo >/dev/null 2>&1; then
-        SUDO="sudo"
-    else
-        echo "❌ sudo not found. Run as root or install sudo."
-        exit 1
-    fi
-fi
-
 run_root() {
-    if [[ -n "$SUDO" ]]; then
+    if [[ ${EUID} -eq 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
         sudo "$@"
     else
-        "$@"
+        echo "❌ Administrator permission is needed; install sudo or run this command as root."
+        return 1
     fi
 }
 
-echo "=== Installing Firecracker ==="
+resolve_runtime_user() {
+    if [[ -n "${RUNTIME_USER_OVERRIDE}" ]]; then
+        printf '%s\n' "${RUNTIME_USER_OVERRIDE}"
+    elif [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+        printf '%s\n' "${SUDO_USER}"
+    elif [[ ${EUID} -ne 0 ]]; then
+        id -un
+    else
+        printf '%s\n' "root"
+    fi
+}
 
-# Version precedence: --firecracker-version flag > SMOLVM_FIRECRACKER_VERSION > FC_VERSION (legacy) > default.
+resolve_user_home() {
+    local user="$1"
+    local home=""
+    if command -v getent >/dev/null 2>&1; then
+        home="$(getent passwd "${user}" 2>/dev/null | cut -d: -f6 || true)"
+    fi
+    if [[ -z "${home}" && "${user}" == "$(id -un)" ]]; then
+        home="${HOME:-}"
+    fi
+    if [[ -z "${home}" ]]; then
+        echo "❌ Home folder for '${user}' was not found; rerun with '--firecracker-dir /absolute/path'." >&2
+        return 1
+    fi
+    printf '%s\n' "${home}"
+}
+
+runtime_user="$(resolve_runtime_user)"
+if ! id "${runtime_user}" >/dev/null 2>&1; then
+    echo "❌ User '${runtime_user}' does not exist; rerun with '--runtime-user $(id -un)'."
+    exit 1
+fi
+runtime_group="$(id -gn "${runtime_user}")"
+runtime_home="$(resolve_user_home "${runtime_user}")"
+
+if [[ -n "${FIRECRACKER_DIR_OVERRIDE}" ]]; then
+    FIRECRACKER_DIR="${FIRECRACKER_DIR_OVERRIDE}"
+elif [[ -n "${SMOLVM_FIRECRACKER_DIR+x}" ]]; then
+    if [[ -z "${SMOLVM_FIRECRACKER_DIR//[[:space:]]/}" ]]; then
+        echo "❌ SMOLVM_FIRECRACKER_DIR is empty; unset it or set it to an absolute folder."
+        exit 1
+    fi
+    FIRECRACKER_DIR="${SMOLVM_FIRECRACKER_DIR}"
+else
+    FIRECRACKER_DIR="${runtime_home}/.smolvm/bin"
+fi
+
+if [[ "${FIRECRACKER_DIR}" != /* ]]; then
+    echo "❌ Firecracker folder must be absolute: '${FIRECRACKER_DIR}'; rerun with '--firecracker-dir /absolute/path'."
+    exit 1
+fi
+if [[ -e "${FIRECRACKER_DIR}" && ! -d "${FIRECRACKER_DIR}" ]]; then
+    echo "❌ Firecracker folder is a file: '${FIRECRACKER_DIR}'; choose another folder with '--firecracker-dir'."
+    exit 1
+fi
+
+user_scoped_dir=false
+if [[ "${FIRECRACKER_DIR}" == "${runtime_home}" || "${FIRECRACKER_DIR}" == "${runtime_home}/"* ]]; then
+    user_scoped_dir=true
+fi
+
 if [[ -n "${FC_VERSION_OVERRIDE}" ]]; then
     FC_VERSION="${FC_VERSION_OVERRIDE}"
 elif [[ -n "${SMOLVM_FIRECRACKER_VERSION:-}" ]]; then
@@ -109,53 +176,103 @@ elif [[ -n "${SMOLVM_FIRECRACKER_VERSION:-}" ]]; then
 else
     FC_VERSION="${FC_VERSION:-v1.14.1}"
 fi
-
 if [[ ! "${FC_VERSION}" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    echo "❌ Firecracker version '${FC_VERSION}' is not a valid release tag."
-    echo "   Allowed: letters, digits, '.', '_', '-' (e.g. 'v1.14.1')."
+    echo "❌ Firecracker version '${FC_VERSION}' is invalid; use a tag such as 'v1.14.1'."
     exit 1
 fi
 
-ARCH=$(uname -m)
+ARCH="$(uname -m)"
+if [[ "${ARCH}" != "x86_64" && "${ARCH}" != "aarch64" ]]; then
+    echo "❌ Firecracker does not support this machine architecture: '${ARCH}'."
+    exit 1
+fi
 
 if [[ "${REQUIRE_KVM}" == "true" && ! -e /dev/kvm ]]; then
-    echo "ERROR: /dev/kvm not found. KVM is required."
+    echo "❌ Hardware virtualization is missing; enable KVM, then rerun this command."
     exit 1
 fi
 
-if [[ "$SKIP_DEPS" == "true" ]]; then
-    for cmd in wget tar; do
-        if ! command -v "$cmd" >/dev/null 2>&1; then
-            echo "❌ Missing required command: $cmd (install it or rerun without --skip-deps)"
-            exit 1
-        fi
-    done
-else
-    run_root apt-get update -qq
-    run_root apt-get install -y curl wget jq nftables e2fsprogs -qq
+missing_tools=()
+for cmd in wget tar; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        missing_tools+=("${cmd}")
+    fi
+done
+
+if [[ ${#missing_tools[@]} -ne 0 ]]; then
+    if [[ "${SKIP_DEPS}" == "true" ]]; then
+        echo "❌ Required commands are missing: ${missing_tools[*]}; install them, then rerun this command."
+        exit 1
+    fi
+    if [[ -e /run/ostree-booted ]] && command -v rpm-ostree >/dev/null 2>&1; then
+        echo "❌ Required commands are missing: ${missing_tools[*]}; run 'sudo rpm-ostree install ${missing_tools[*]}', reboot, then rerun this command."
+        exit 1
+    elif command -v apt-get >/dev/null 2>&1; then
+        run_root apt-get update -qq
+        run_root apt-get install -y -qq "${missing_tools[@]}"
+    elif command -v dnf >/dev/null 2>&1; then
+        run_root dnf install -y "${missing_tools[@]}"
+    else
+        echo "❌ Required commands are missing: ${missing_tools[*]}; install them with your operating system, then rerun this command."
+        exit 1
+    fi
 fi
 
-cd /tmp
-wget -q "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-${ARCH}.tgz"
-tar -xzf "firecracker-${FC_VERSION}-${ARCH}.tgz"
+work_dir="$(mktemp -d)"
+staged_path=""
+cleanup() {
+    rm -rf "${work_dir}"
+    if [[ -n "${staged_path}" && -e "${staged_path}" ]]; then
+        rm -f "${staged_path}" 2>/dev/null || run_root rm -f "${staged_path}" || true
+    fi
+}
+trap cleanup EXIT
 
-run_root cp "release-${FC_VERSION}-${ARCH}/firecracker-${FC_VERSION}-${ARCH}" /usr/local/bin/firecracker
-run_root cp "release-${FC_VERSION}-${ARCH}/jailer-${FC_VERSION}-${ARCH}" /usr/local/bin/jailer
-run_root chmod +x /usr/local/bin/firecracker /usr/local/bin/jailer
+tarball_path="${work_dir}/firecracker.tgz"
+release_dir="${work_dir}/release-${FC_VERSION}-${ARCH}"
+source_binary="${release_dir}/firecracker-${FC_VERSION}-${ARCH}"
+url="https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-${ARCH}.tgz"
 
-run_root groupadd -g 2000 firecracker 2>/dev/null || true
-run_root useradd -u 2000 -g firecracker -s /bin/false -d /srv/jailer firecracker 2>/dev/null || true
-run_root mkdir -p /srv/jailer
-run_root chown firecracker:firecracker /srv/jailer
+echo "Downloading Firecracker ${FC_VERSION} for ${ARCH}..."
+wget -q -O "${tarball_path}" "${url}"
+tar -xzf "${tarball_path}" -C "${work_dir}"
+if [[ ! -f "${source_binary}" ]]; then
+    echo "❌ The downloaded Firecracker archive does not contain '${source_binary##*/}'; retry the setup."
+    exit 1
+fi
 
-rm -rf "/tmp/release-${FC_VERSION}-${ARCH}" "/tmp/firecracker-${FC_VERSION}-${ARCH}.tgz"
+if [[ ${EUID} -eq 0 && "${runtime_user}" != "root" && "${user_scoped_dir}" == "true" ]]; then
+    if [[ "${FIRECRACKER_DIR}" == "${runtime_home}/.smolvm/bin" ]]; then
+        install -d -o "${runtime_user}" -g "${runtime_group}" -m 0755 \
+            "${runtime_home}/.smolvm" "${FIRECRACKER_DIR}"
+    else
+        install -d -o "${runtime_user}" -g "${runtime_group}" -m 0755 "${FIRECRACKER_DIR}"
+    fi
+elif ! mkdir -p "${FIRECRACKER_DIR}" 2>/dev/null; then
+    run_root install -d -m 0755 "${FIRECRACKER_DIR}"
+fi
 
-echo ""
-echo "✅ Firecracker Installation Complete"
-echo "   Firecracker: $(firecracker --version 2>&1 | head -1)"
-echo "   Jailer: $(jailer --version 2>&1 | head -1)"
+staged_path="${FIRECRACKER_DIR}/.firecracker.$$.tmp"
+if ! install -m 0755 "${source_binary}" "${staged_path}" 2>/dev/null; then
+    run_root install -m 0755 "${source_binary}" "${staged_path}"
+fi
+if ! mv -f "${staged_path}" "${FIRECRACKER_DIR}/firecracker" 2>/dev/null; then
+    run_root mv -f "${staged_path}" "${FIRECRACKER_DIR}/firecracker"
+fi
+staged_path=""
+if [[ ${EUID} -eq 0 && "${runtime_user}" != "root" && "${user_scoped_dir}" == "true" ]]; then
+    chown "${runtime_user}:${runtime_group}" "${FIRECRACKER_DIR}/firecracker"
+fi
 
-if [[ "$WITH_IMAGES" == "true" ]]; then
+if [[ ! -x "${FIRECRACKER_DIR}/firecracker" ]]; then
+    echo "❌ Firecracker was not installed at '${FIRECRACKER_DIR}/firecracker'; restore write access to that folder and retry."
+    exit 1
+fi
+
+echo "✅ Firecracker ${FC_VERSION} installed at '${FIRECRACKER_DIR}/firecracker'."
+"${FIRECRACKER_DIR}/firecracker" --version 2>&1 | head -1
+
+if [[ "${WITH_IMAGES}" == "true" ]]; then
     echo ""
     bash "$(cd "$(dirname "$0")/.." && pwd)/download-images.sh"
 fi

--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # system-setup.sh - System-level setup for SmolVM (no Python/venv).
-# Installs Firecracker/Jailer and host dependencies. Docker is optional.
+# Installs Firecracker and host dependencies. Docker is optional.
 # Can optionally configure command-scoped NOPASSWD sudo for runtime operations.
 set -euo pipefail
 
@@ -42,6 +42,8 @@ RUNTIME_USER=""
 SKIP_KVM_CHECK=false
 SKIP_RUNTIME_CHECK=false
 FIRECRACKER_VERSION=""
+FIRECRACKER_DIR=""
+FIRECRACKER_DIR_CONFIGURED=false
 
 usage() {
     cat <<EOF_USAGE
@@ -52,7 +54,7 @@ Installs host dependencies and Firecracker (no Python/venv involvement).
 Options:
   --check-only                   Only validate system prerequisites; do not install.
   --with-docker                  Install Docker (required for SSH image demo).
-  --skip-deps                    Skip apt dependency install (assumes deps already present).
+  --skip-deps                    Do not install missing operating-system packages.
   --configure-runtime            Configure scoped NOPASSWD sudoers for SmolVM runtime.
   --remove-runtime-config        Remove generated runtime sudoers config.
   --runtime-user <user>          Target user for runtime sudoers/docker group (default: invoking user).
@@ -63,6 +65,8 @@ Options:
   --skip-runtime-check           Skip the post-install sudoers self-test on the live host.
   --firecracker-version <ver>    Pin Firecracker release tag (e.g. v1.14.1). Falls back
                                  to \$SMOLVM_FIRECRACKER_VERSION or the built-in default.
+  --firecracker-dir <dir>        Folder for Firecracker (default:
+                                 \$SMOLVM_FIRECRACKER_DIR or ~/.smolvm/bin).
   -h, --help                     Show this help.
 EOF_USAGE
 }
@@ -105,11 +109,19 @@ while [[ $# -gt 0 ]]; do
             ;;
         --firecracker-version)
             if [[ $# -lt 2 ]]; then
-                echo "❌ --firecracker-version requires a value"
-                usage
+                echo "❌ --firecracker-version needs a release tag such as 'v1.14.1'."
                 exit 1
             fi
             FIRECRACKER_VERSION="$2"
+            shift
+            ;;
+        --firecracker-dir)
+            if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+                echo "❌ --firecracker-dir needs an absolute folder."
+                exit 1
+            fi
+            FIRECRACKER_DIR="$2"
+            FIRECRACKER_DIR_CONFIGURED=true
             shift
             ;;
         -h|--help)
@@ -151,6 +163,75 @@ resolve_runtime_user() {
     fi
 
     echo ""
+}
+
+resolve_user_home() {
+    local runtime_user="$1"
+    local runtime_home=""
+    if command -v getent >/dev/null 2>&1; then
+        runtime_home="$(getent passwd "${runtime_user}" 2>/dev/null | cut -d: -f6 || true)"
+    fi
+    if [[ -z "${runtime_home}" && "${runtime_user}" == "$(id -un)" ]]; then
+        runtime_home="${HOME:-}"
+    fi
+    if [[ -z "${runtime_home}" ]]; then
+        echo "❌ Home folder for '${runtime_user}' was not found; rerun with '--firecracker-dir /absolute/path'." >&2
+        return 1
+    fi
+    printf '%s\n' "${runtime_home}"
+}
+
+resolve_firecracker_directory() {
+    local runtime_user
+    local runtime_home
+    runtime_user="$(resolve_runtime_user)"
+    if [[ -z "${runtime_user}" && ${EUID} -eq 0 ]]; then
+        runtime_user="root"
+    fi
+    if [[ -z "${runtime_user}" ]]; then
+        echo "❌ SmolVM could not determine your account; rerun with '--runtime-user $(id -un)'."
+        return 1
+    fi
+    runtime_home="$(resolve_user_home "${runtime_user}")"
+
+    if [[ "${FIRECRACKER_DIR_CONFIGURED}" != "true" && -n "${SMOLVM_FIRECRACKER_DIR+x}" ]]; then
+        if [[ -z "${SMOLVM_FIRECRACKER_DIR//[[:space:]]/}" ]]; then
+            echo "❌ SMOLVM_FIRECRACKER_DIR is empty; unset it or set it to an absolute folder."
+            return 1
+        fi
+        FIRECRACKER_DIR="${SMOLVM_FIRECRACKER_DIR}"
+        FIRECRACKER_DIR_CONFIGURED=true
+    fi
+    if [[ -z "${FIRECRACKER_DIR}" ]]; then
+        FIRECRACKER_DIR="${runtime_home}/.smolvm/bin"
+    fi
+    if [[ "${FIRECRACKER_DIR}" != /* ]]; then
+        echo "❌ Firecracker folder must be absolute: '${FIRECRACKER_DIR}'; rerun with '--firecracker-dir /absolute/path'."
+        return 1
+    fi
+    if [[ -e "${FIRECRACKER_DIR}" && ! -d "${FIRECRACKER_DIR}" ]]; then
+        echo "❌ Firecracker folder is a file: '${FIRECRACKER_DIR}'; choose another folder with '--firecracker-dir'."
+        return 1
+    fi
+}
+
+find_firecracker_path() {
+    local selected="${FIRECRACKER_DIR}/firecracker"
+    if [[ "${FIRECRACKER_DIR_CONFIGURED}" == "true" ]]; then
+        if [[ -f "${selected}" && -x "${selected}" ]]; then
+            printf '%s\n' "${selected}"
+        fi
+        return 0
+    fi
+
+    local system_path
+    system_path="$(command -v firecracker 2>/dev/null || true)"
+    if [[ -n "${system_path}" ]]; then
+        printf '%s\n' "${system_path}"
+    elif [[ -f "${selected}" && -x "${selected}" ]]; then
+        printf '%s\n' "${selected}"
+    fi
+    return 0
 }
 
 ensure_group_membership() {
@@ -285,6 +366,8 @@ if [[ "${REMOVE_RUNTIME_CONFIG}" == "true" ]]; then
     exit 0
 fi
 
+resolve_firecracker_directory
+
 missing_items=()
 
 check_kvm() {
@@ -309,35 +392,99 @@ check_cmd() {
     fi
 }
 
+check_firecracker() {
+    local path
+    path="$(find_firecracker_path)"
+    if [[ -n "${path}" ]]; then
+        echo "  ✅ Firecracker (${path})"
+    else
+        echo "  ❌ Firecracker (${FIRECRACKER_DIR}/firecracker)"
+        missing_items+=("Firecracker")
+    fi
+}
+
 run_checks() {
     check_kvm
     check_cmd "ip" "ip (iproute2)"
     check_cmd "nft" "nft (nftables)"
     check_cmd "ssh" "ssh (openssh-client)"
-    check_cmd "firecracker" "firecracker"
+    check_firecracker
     if [[ "${WITH_DOCKER}" == "true" ]]; then
         check_cmd "docker" "docker"
     fi
 }
 
-required_runtime_cmds=("ip" "nft" "ssh")
-required_install_cmds=("wget" "tar")
-if [[ "${WITH_DOCKER}" == "true" ]]; then
-    required_install_cmds+=("curl")
-fi
+missing_commands=()
 
-check_required_cmds() {
-    local missing=()
+collect_missing_commands() {
+    missing_commands=()
+    local cmd
     for cmd in "$@"; do
-        if ! command -v "$cmd" >/dev/null 2>&1; then
-            missing+=("$cmd")
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            missing_commands+=("${cmd}")
         fi
     done
-    if [[ ${#missing[@]} -ne 0 ]]; then
-        echo "❌ Missing required commands: ${missing[*]}"
+}
+
+packages_for_commands() {
+    local family="$1"
+    shift
+    local cmd
+    local package
+    local packages=()
+    for cmd in "$@"; do
+        package="${cmd}"
+        case "${family}:${cmd}" in
+            apt:ip) package="iproute2" ;;
+            apt:nft) package="nftables" ;;
+            apt:ssh) package="openssh-client" ;;
+            apt:sysctl) package="procps" ;;
+            apt:visudo) package="sudo" ;;
+            apt:install) package="coreutils" ;;
+            dnf:ip) package="iproute" ;;
+            dnf:nft) package="nftables" ;;
+            dnf:ssh) package="openssh-clients" ;;
+            dnf:sysctl) package="procps-ng" ;;
+            dnf:visudo) package="sudo" ;;
+            dnf:install) package="coreutils" ;;
+        esac
+        packages+=("${package}")
+    done
+    printf '%s\n' "${packages[@]}"
+}
+
+install_missing_dependencies() {
+    if [[ ${#missing_commands[@]} -eq 0 ]]; then
+        echo "✅ Host dependencies already installed"
+        return 0
+    fi
+
+    local packages=()
+    if [[ -e /run/ostree-booted ]] && command -v rpm-ostree >/dev/null 2>&1; then
+        mapfile -t packages < <(packages_for_commands dnf "${missing_commands[@]}")
+        echo "❌ Required commands are missing: ${missing_commands[*]}; run 'sudo rpm-ostree install ${packages[*]}', reboot, then run 'smolvm setup --skip-deps'."
         return 1
     fi
-    return 0
+
+    if command -v apt-get >/dev/null 2>&1; then
+        mapfile -t packages < <(packages_for_commands apt "${missing_commands[@]}")
+        if ! apt-get update -qq; then
+            echo "⚠️  Package-list refresh failed; SmolVM will try the existing package list."
+        fi
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${packages[@]}"
+    elif command -v dnf >/dev/null 2>&1; then
+        mapfile -t packages < <(packages_for_commands dnf "${missing_commands[@]}")
+        dnf install -y "${packages[@]}"
+    else
+        echo "❌ Required commands are missing: ${missing_commands[*]}; install them with your operating system, then run 'smolvm setup --skip-deps'."
+        return 1
+    fi
+
+    collect_missing_commands "${required_commands[@]}"
+    if [[ ${#missing_commands[@]} -ne 0 ]]; then
+        echo "❌ Required commands are still missing: ${missing_commands[*]}; install them, then run 'smolvm setup --skip-deps'."
+        return 1
+    fi
 }
 
 if [[ "${CHECK_ONLY}" == "true" ]]; then
@@ -378,60 +525,51 @@ if [[ -e /dev/kvm ]]; then
     install_kvm_udev_rule
 fi
 
+firecracker_path="$(find_firecracker_path)"
+required_commands=("ip" "nft" "ssh")
+if [[ "${CONFIGURE_RUNTIME}" == "true" ]]; then
+    required_commands+=("sysctl" "visudo" "install")
+fi
+if [[ -z "${firecracker_path}" ]]; then
+    required_commands+=("wget" "tar")
+fi
+if [[ "${WITH_DOCKER}" == "true" ]]; then
+    required_commands+=("curl")
+fi
+collect_missing_commands "${required_commands[@]}"
+
 if [[ "${SKIP_DEPS}" == "true" ]]; then
-    echo "Skipping dependency installation (--skip-deps)"
-    if ! check_required_cmds "${required_runtime_cmds[@]}" "${required_install_cmds[@]}"; then
-        echo "Install missing commands or rerun without --skip-deps."
+    echo "Skipping operating-system package installation (--skip-deps)"
+    if [[ ${#missing_commands[@]} -ne 0 ]]; then
+        echo "❌ Required commands are missing: ${missing_commands[*]}; install them, then run 'smolvm setup --skip-deps'."
         exit 1
     fi
 else
-    echo "Installing host dependencies..."
-    if ! command -v apt-get >/dev/null 2>&1; then
-        echo "❌ apt-get not found. Install dependencies manually or rerun with --skip-deps."
-        exit 1
-    fi
-
-    update_output=""
-    if ! update_output=$(apt-get update -qq 2>&1); then
-        echo "⚠️  apt-get update failed. Continuing with existing package lists."
-        echo "    If installs fail, fix apt sources or rerun with --skip-deps."
-    fi
-    if [[ -n "${update_output}" ]]; then
-        echo "${update_output}"
-        if echo "${update_output}" | grep -Eq "EXPKEYSIG|NO_PUBKEY|The following signatures were invalid|Failed to fetch|^W:"; then
-            echo "⚠️  apt-get update reported repository warnings."
-            echo "    If installs fail, fix /etc/apt/sources.list(.d) or rerun with --skip-deps."
-        fi
-    fi
-
-    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl wget jq nftables iproute2 e2fsprogs openssh-client tar; then
-        echo "❌ apt-get install failed. Fix apt sources or install deps manually, then rerun with --skip-deps."
-        exit 1
-    fi
-
-    if ! check_required_cmds "${required_runtime_cmds[@]}" "${required_install_cmds[@]}"; then
-        echo "❌ Required commands are still missing after install."
-        exit 1
-    fi
+    install_missing_dependencies
 fi
 
-if command -v firecracker >/dev/null 2>&1; then
-    echo "✅ Firecracker already installed: $(command -v firecracker)"
+if [[ -n "${firecracker_path}" ]]; then
+    echo "✅ Firecracker already installed: ${firecracker_path}"
 else
     if [[ ! -f "${INSTALL_SCRIPT}" ]]; then
-        echo "❌ install.sh not found at ${INSTALL_SCRIPT}"
+        echo "❌ Firecracker installer is missing: '${INSTALL_SCRIPT}'; reinstall SmolVM, then run 'smolvm setup' again."
         exit 1
     fi
-    echo "Installing Firecracker..."
-    install_args=(--skip-deps)
+    echo "Installing Firecracker in '${FIRECRACKER_DIR}'..."
+    install_args=(--skip-deps --firecracker-dir "${FIRECRACKER_DIR}")
+    runtime_user="$(resolve_runtime_user)"
+    if [[ -n "${runtime_user}" ]]; then
+        install_args+=(--runtime-user "${runtime_user}")
+    fi
     if [[ -n "${FIRECRACKER_VERSION}" ]]; then
         install_args+=(--firecracker-version "${FIRECRACKER_VERSION}")
     fi
     bash "${INSTALL_SCRIPT}" "${install_args[@]}"
+    firecracker_path="$(find_firecracker_path)"
 fi
 
-if ! command -v firecracker >/dev/null 2>&1; then
-    echo "❌ Firecracker install failed: firecracker not found in PATH"
+if [[ -z "${firecracker_path}" ]]; then
+    echo "❌ Firecracker is missing from '${FIRECRACKER_DIR}'; run 'smolvm setup --firecracker-dir ${FIRECRACKER_DIR}' to install it."
     exit 1
 fi
 
@@ -439,8 +577,12 @@ if [[ "${WITH_DOCKER}" == "true" ]]; then
     if command -v docker >/dev/null 2>&1; then
         echo "✅ Docker already installed"
     else
+        if [[ -e /run/ostree-booted ]]; then
+            echo "❌ Docker is not installed; install it through your operating system, or rerun 'smolvm setup' without '--with-docker'."
+            exit 1
+        fi
         if ! command -v curl >/dev/null 2>&1; then
-            echo "❌ curl not found (required for Docker install). Install curl or rerun without --skip-deps."
+            echo "❌ curl is missing; install it, then rerun 'smolvm setup --with-docker'."
             exit 1
         fi
         echo "Installing Docker..."

--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -182,27 +182,26 @@ resolve_user_home() {
 }
 
 resolve_firecracker_directory() {
-    local runtime_user
-    local runtime_home
-    runtime_user="$(resolve_runtime_user)"
-    if [[ -z "${runtime_user}" && ${EUID} -eq 0 ]]; then
-        runtime_user="root"
-    fi
-    if [[ -z "${runtime_user}" ]]; then
-        echo "❌ SmolVM could not determine your account; rerun with '--runtime-user $(id -un)'."
-        return 1
-    fi
-    runtime_home="$(resolve_user_home "${runtime_user}")"
-
     if [[ "${FIRECRACKER_DIR_CONFIGURED}" != "true" && -n "${SMOLVM_FIRECRACKER_DIR+x}" ]]; then
         if [[ -z "${SMOLVM_FIRECRACKER_DIR//[[:space:]]/}" ]]; then
-            echo "❌ SMOLVM_FIRECRACKER_DIR is empty; unset it or set it to an absolute folder."
+            echo "❌ SMOLVM_FIRECRACKER_DIR is empty; run 'unset SMOLVM_FIRECRACKER_DIR', then run 'smolvm setup'."
             return 1
         fi
         FIRECRACKER_DIR="${SMOLVM_FIRECRACKER_DIR}"
         FIRECRACKER_DIR_CONFIGURED=true
     fi
     if [[ -z "${FIRECRACKER_DIR}" ]]; then
+        local runtime_user
+        local runtime_home
+        runtime_user="$(resolve_runtime_user)"
+        if [[ -z "${runtime_user}" && ${EUID} -eq 0 ]]; then
+            runtime_user="root"
+        fi
+        if [[ -z "${runtime_user}" ]]; then
+            echo "❌ SmolVM could not determine your account; rerun with '--runtime-user $(id -un)'."
+            return 1
+        fi
+        runtime_home="$(resolve_user_home "${runtime_user}")"
         FIRECRACKER_DIR="${runtime_home}/.smolvm/bin"
     fi
     if [[ "${FIRECRACKER_DIR}" != /* ]]; then
@@ -569,7 +568,8 @@ else
 fi
 
 if [[ -z "${firecracker_path}" ]]; then
-    echo "❌ Firecracker is missing from '${FIRECRACKER_DIR}'; run 'smolvm setup --firecracker-dir ${FIRECRACKER_DIR}' to install it."
+    printf -v firecracker_dir_arg '%q' "${FIRECRACKER_DIR}"
+    echo "❌ Firecracker is missing from '${FIRECRACKER_DIR}'; run this command: smolvm setup --firecracker-dir ${firecracker_dir_arg}"
     exit 1
 fi
 

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import shlex
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -470,6 +471,16 @@ def sandbox_prune(
 @click.option("--skip-kvm-check", cls=LinuxOnlyOption, is_flag=True)
 @click.option("--skip-runtime-check", cls=LinuxOnlyOption, is_flag=True)
 @click.option("--firecracker-version", cls=LinuxOnlyOption, default=None, metavar="VER")
+@click.option(
+    "--firecracker-dir",
+    cls=LinuxOnlyOption,
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    metavar="DIR",
+    help=(
+        "Folder for the Firecracker program (default: $SMOLVM_FIRECRACKER_DIR or ~/.smolvm/bin)."
+    ),
+)
 def setup(
     check_only: bool,
     with_docker: bool,
@@ -483,6 +494,7 @@ def setup(
     skip_kvm_check: bool,
     skip_runtime_check: bool,
     firecracker_version: str | None,
+    firecracker_dir: Path | None,
 ) -> Any:
     _before_command(skip_update_notice=assets_dir)
     return _handlers()._run_setup(
@@ -498,6 +510,7 @@ def setup(
         skip_kvm_check=skip_kvm_check,
         skip_runtime_check=skip_runtime_check,
         firecracker_version=firecracker_version,
+        firecracker_dir=firecracker_dir,
         assets_dir=assets_dir,
     )
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -576,7 +576,7 @@ def _run_setup(
                 console_stdout().print(
                     "Firecracker was installed in "
                     f"'{escape(str(resolved_dir))}'; run "
-                    f"'export SMOLVM_FIRECRACKER_DIR={escape(export_value)}' "
+                    f"export SMOLVM_FIRECRACKER_DIR={escape(export_value)} "
                     "before your next SmolVM command."
                 )
         return result

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -476,9 +476,16 @@ def _run_setup(
     skip_kvm_check: bool,
     skip_runtime_check: bool,
     firecracker_version: str | None,
+    firecracker_dir: Path | None,
     assets_dir: bool,
 ) -> int:
     """Handle ``smolvm setup``."""
+    from smolvm.host.paths import (
+        configured_firecracker_dir,
+        default_firecracker_dir,
+        directory_is_on_path,
+        resolve_firecracker_dir,
+    )
     from smolvm.host.setup import SetupOptions, packaged_asset_root, run_setup
 
     if assets_dir:
@@ -525,6 +532,8 @@ def _run_setup(
         invalid_remove_runtime_flags.append("--no-configure-runtime")
     if skip_deps:
         invalid_remove_runtime_flags.append("--skip-deps")
+    if firecracker_dir is not None:
+        invalid_remove_runtime_flags.append("--firecracker-dir")
 
     if remove_runtime_config and invalid_remove_runtime_flags:
         raise click.UsageError(
@@ -543,6 +552,7 @@ def _run_setup(
         skip_kvm_check=skip_kvm_check,
         skip_runtime_check=skip_runtime_check,
         firecracker_version=firecracker_version,
+        firecracker_dir=firecracker_dir,
     )
 
     if options.for_bake:
@@ -552,7 +562,24 @@ def _run_setup(
         )
 
     try:
-        return run_setup(options)
+        result = run_setup(options)
+        if result == 0 and not check_only and firecracker_dir is not None:
+            resolved_dir = resolve_firecracker_dir(firecracker_dir)
+            environment_dir = configured_firecracker_dir()
+            discoverable = (
+                resolved_dir == default_firecracker_dir()
+                or environment_dir == resolved_dir
+                or directory_is_on_path(resolved_dir)
+            )
+            if not discoverable:
+                export_value = shlex.quote(str(resolved_dir))
+                console_stdout().print(
+                    "Firecracker was installed in "
+                    f"'{escape(str(resolved_dir))}'; run "
+                    f"'export SMOLVM_FIRECRACKER_DIR={escape(export_value)}' "
+                    "before your next SmolVM command."
+                )
+        return result
     except Exception as exc:
         return _emit_cli_error("setup", 1, exc, json_output=False)
 

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import platform
 import re
+import shlex
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -32,6 +33,7 @@ from smolvm.cli.output import console_stdout, emit_json, render_error, status_st
 from smolvm.exceptions import SmolVMError
 from smolvm.host.manager import HostManager
 from smolvm.host.network import check_network_prerequisites
+from smolvm.host.paths import configured_firecracker_dir
 from smolvm.runtime.backends import (
     BACKEND_AUTO,
     BACKEND_FIRECRACKER,
@@ -603,15 +605,23 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
         checks.append(_check_kvm_runtime())
 
         firecracker_path = host.find_firecracker()
+        configured_dir = configured_firecracker_dir()
+        missing_detail = (
+            f"Not found at {configured_dir / 'firecracker'}"
+            if configured_dir is not None
+            else "Not found in PATH or ~/.smolvm/bin"
+        )
+        setup_command = (
+            "smolvm setup"
+            if configured_dir is None
+            else f"smolvm setup --firecracker-dir {shlex.quote(str(configured_dir))}"
+        )
         checks.append(
             DoctorCheck(
                 name="firecracker",
                 status="pass" if firecracker_path is not None else "fail",
-                detail=(
-                    str(firecracker_path)
-                    if firecracker_path is not None
-                    else "binary not found in PATH or ~/.smolvm/bin"
-                ),
+                detail=str(firecracker_path) if firecracker_path is not None else missing_detail,
+                fix=None if firecracker_path is not None else f"Run '{setup_command}'.",
             )
         )
 

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -621,7 +621,7 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
                 name="firecracker",
                 status="pass" if firecracker_path is not None else "fail",
                 detail=str(firecracker_path) if firecracker_path is not None else missing_detail,
-                fix=None if firecracker_path is not None else f"Run '{setup_command}'.",
+                fix=None if firecracker_path is not None else f"Run {setup_command}.",
             )
         )
 

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -20,6 +20,7 @@ Validates the host environment and manages the Firecracker binary.
 import logging
 import os
 import platform
+import shlex
 import shutil
 import stat
 import tarfile
@@ -31,6 +32,13 @@ import requests
 from pydantic import BaseModel
 
 from smolvm.exceptions import HostError
+from smolvm.host.paths import (
+    default_firecracker_dir,
+    resolve_firecracker_dir,
+)
+from smolvm.host.paths import (
+    find_firecracker as find_firecracker_binary,
+)
 from smolvm.utils import unsafe_tar_member_kind, which
 
 logger = logging.getLogger(__name__)
@@ -83,17 +91,33 @@ class HostManager:
     SMOLVM_HOME = Path.home() / ".smolvm"
     BIN_DIR = SMOLVM_HOME / "bin"
 
-    def __init__(self, firecracker_version: str = DEFAULT_FIRECRACKER_VERSION) -> None:
+    def __init__(
+        self,
+        firecracker_version: str = DEFAULT_FIRECRACKER_VERSION,
+        firecracker_dir: str | Path | None = None,
+    ) -> None:
         """Initialize the host manager.
 
         Args:
             firecracker_version: Pinned Firecracker version to install
                 when auto-installing (e.g., "v1.14.1").
+            firecracker_dir: Folder containing SmolVM's private Firecracker
+                binary. Explicit values override ``SMOLVM_FIRECRACKER_DIR``.
         """
         if not firecracker_version:
             raise ValueError("firecracker_version cannot be empty")
 
         self.firecracker_version = firecracker_version
+        self._firecracker_dir = firecracker_dir
+
+    def _firecracker_dir_input(self) -> str | Path | None:
+        """Return explicit configuration, including the legacy instance alias."""
+        return self.__dict__.get("BIN_DIR", self._firecracker_dir)
+
+    @property
+    def firecracker_dir(self) -> Path:
+        """Return the configured installation folder at call time."""
+        return resolve_firecracker_dir(self._firecracker_dir_input())
 
     # ------------------------------------------------------------------
     # Public API
@@ -151,26 +175,14 @@ class HostManager:
         return missing
 
     def find_firecracker(self) -> Path | None:
-        """Find the Firecracker binary.
-
-        Searches:
-        1. System PATH
-        2. ``~/.smolvm/bin/firecracker``
-
-        Returns:
-            Path to the binary, or None if not found.
-        """
-        # Check system PATH first
-        system_path = which("firecracker")
-        if system_path is not None:
-            logger.debug("Found firecracker in PATH: %s", system_path)
-            return system_path
-
-        # Check SmolVM local install
-        local_path = self.BIN_DIR / "firecracker"
-        if local_path.exists() and os.access(local_path, os.X_OK):
-            logger.debug("Found firecracker at: %s", local_path)
-            return local_path
+        """Find Firecracker in the configured folder, PATH, or user default."""
+        path = find_firecracker_binary(
+            self._firecracker_dir_input(),
+            path_lookup=which,
+        )
+        if path is not None:
+            logger.debug("Found firecracker at: %s", path)
+            return path
 
         logger.debug("Firecracker binary not found")
         return None
@@ -205,16 +217,20 @@ class HostManager:
         url = FIRECRACKER_RELEASE_URL.format(version=version, arch=arch)
         logger.info("Downloading Firecracker %s for %s from %s", version, arch, url)
 
-        # Ensure install directory exists
-        self.BIN_DIR.mkdir(parents=True, exist_ok=True)
-        dest = self.BIN_DIR / "firecracker"
+        firecracker_dir = self.firecracker_dir
+        dest = firecracker_dir / "firecracker"
 
         try:
+            firecracker_dir.mkdir(parents=True, exist_ok=True)
             self._download_and_extract(url, dest, version, arch)
         except requests.RequestException as e:
             raise HostError(f"Failed to download Firecracker: {e}") from e
         except (tarfile.TarError, OSError) as e:
-            raise HostError(f"Failed to extract Firecracker: {e}") from e
+            fallback = shlex.quote(str(default_firecracker_dir()))
+            raise HostError(
+                f"Could not install Firecracker in '{firecracker_dir}': {e}; "
+                f"fix that folder, or run 'smolvm setup --firecracker-dir {fallback}'."
+            ) from e
 
         # Verify the binary exists and is executable
         if not dest.exists():

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -229,7 +229,7 @@ class HostManager:
             fallback = shlex.quote(str(default_firecracker_dir()))
             raise HostError(
                 f"Could not install Firecracker in '{firecracker_dir}': {e}; "
-                f"fix that folder, or run 'smolvm setup --firecracker-dir {fallback}'."
+                f"fix that folder, or run smolvm setup --firecracker-dir {fallback}."
             ) from e
 
         # Verify the binary exists and is executable

--- a/src/smolvm/host/paths.py
+++ b/src/smolvm/host/paths.py
@@ -31,7 +31,8 @@ def _normalize_directory(value: str | Path, *, source: str) -> Path:
     if isinstance(value, str) and not value.strip():
         if source == SMOLVM_FIRECRACKER_DIR_ENV:
             raise ValueError(
-                f"{SMOLVM_FIRECRACKER_DIR_ENV} cannot be empty; unset it or set it to a folder."
+                f"{SMOLVM_FIRECRACKER_DIR_ENV} is empty; run "
+                f"'unset {SMOLVM_FIRECRACKER_DIR_ENV}', then run 'smolvm setup'."
             )
         raise ValueError("firecracker_dir cannot be empty; choose a folder for Firecracker.")
 

--- a/src/smolvm/host/paths.py
+++ b/src/smolvm/host/paths.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Writable host paths for SmolVM-managed runtime programs."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+SMOLVM_FIRECRACKER_DIR_ENV = "SMOLVM_FIRECRACKER_DIR"
+
+PathLookup = Callable[[str], str | Path | None]
+
+
+def _normalize_directory(value: str | Path, *, source: str) -> Path:
+    """Expand and absolutize one configured directory without creating it."""
+    if isinstance(value, str) and not value.strip():
+        if source == SMOLVM_FIRECRACKER_DIR_ENV:
+            raise ValueError(
+                f"{SMOLVM_FIRECRACKER_DIR_ENV} cannot be empty; unset it or set it to a folder."
+            )
+        raise ValueError("firecracker_dir cannot be empty; choose a folder for Firecracker.")
+
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path.resolve(strict=False)
+
+
+def default_firecracker_dir() -> Path:
+    """Return the per-user default Firecracker directory at call time."""
+    return (Path.home() / ".smolvm" / "bin").resolve(strict=False)
+
+
+def configured_firecracker_dir(explicit: str | Path | None = None) -> Path | None:
+    """Return an explicit or environment-configured directory, if any."""
+    if explicit is not None:
+        return _normalize_directory(explicit, source="firecracker_dir")
+
+    if SMOLVM_FIRECRACKER_DIR_ENV in os.environ:
+        return _normalize_directory(
+            os.environ[SMOLVM_FIRECRACKER_DIR_ENV],
+            source=SMOLVM_FIRECRACKER_DIR_ENV,
+        )
+    return None
+
+
+def resolve_firecracker_dir(explicit: str | Path | None = None) -> Path:
+    """Resolve explicit, environment, then per-user default configuration."""
+    return configured_firecracker_dir(explicit) or default_firecracker_dir()
+
+
+def firecracker_candidates(
+    explicit: str | Path | None = None,
+    *,
+    path_lookup: PathLookup = shutil.which,
+) -> tuple[Path, ...]:
+    """Return Firecracker candidates in deterministic discovery order.
+
+    An explicit or environment-configured directory is authoritative. Without
+    one, a system ``PATH`` installation wins over SmolVM's per-user default.
+    """
+    configured = configured_firecracker_dir(explicit)
+    if configured is not None:
+        return (configured / "firecracker",)
+
+    candidates: list[Path] = []
+    path_binary = path_lookup("firecracker")
+    if path_binary is not None:
+        candidates.append(Path(path_binary).expanduser().resolve(strict=False))
+    candidates.append(default_firecracker_dir() / "firecracker")
+
+    unique: list[Path] = []
+    for candidate in candidates:
+        if candidate not in unique:
+            unique.append(candidate)
+    return tuple(unique)
+
+
+def find_firecracker(
+    explicit: str | Path | None = None,
+    *,
+    path_lookup: PathLookup = shutil.which,
+) -> Path | None:
+    """Return the first configured regular executable Firecracker binary."""
+    for candidate in firecracker_candidates(explicit, path_lookup=path_lookup):
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def directory_is_on_path(directory: str | Path) -> bool:
+    """Return whether *directory* is already in the current ``PATH``."""
+    target = _normalize_directory(directory, source="firecracker_dir")
+    for raw_entry in os.environ.get("PATH", "").split(os.pathsep):
+        entry = raw_entry or os.curdir
+        try:
+            if _normalize_directory(entry, source="PATH entry") == target:
+                return True
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return False

--- a/src/smolvm/host/setup.py
+++ b/src/smolvm/host/setup.py
@@ -24,6 +24,8 @@ from os import fspath
 from pathlib import Path
 from typing import Literal
 
+from smolvm.host.paths import configured_firecracker_dir
+
 SetupPlatform = Literal["linux", "macos"]
 
 _LINUX_SCRIPT = "system-setup.sh"
@@ -44,6 +46,7 @@ class SetupOptions:
     skip_kvm_check: bool = False
     skip_runtime_check: bool = False
     firecracker_version: str | None = None
+    firecracker_dir: Path | None = None
 
 
 def packaged_asset_root() -> Path:
@@ -136,6 +139,9 @@ def build_setup_command(
             argv.append("--skip-deps")
         if options.runtime_user:
             argv.extend(["--runtime-user", options.runtime_user])
+        configured_dir = configured_firecracker_dir(options.firecracker_dir)
+        if configured_dir is not None:
+            argv.extend(["--firecracker-dir", str(configured_dir)])
         if options.for_bake:
             argv.append("--for-bake")
         if options.skip_kvm_check and not options.for_bake:

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -57,7 +57,8 @@ SSH_BOOT_ARGS = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/i
 # 200+ VMs.  No console= since we don't need serial output in production.
 OPENCLAW_BOOT_ARGS = "reboot=k panic=1 pci=off init=/init 8250.nr_uarts=0"
 
-LOOPFS_HELPER_PATH = Path("/usr/local/libexec/smolvm-loopfs-helper")
+LOOPFS_HELPER_PATH = Path("/var/lib/smolvm/libexec/smolvm-loopfs-helper")
+LEGACY_LOOPFS_HELPER_PATH = Path("/usr/local/libexec/smolvm-loopfs-helper")
 
 # The SmolVM guest agent (vsock control plane). It is baked into every image
 # built here and launched by /init. The Rust crate lives in the repository
@@ -1845,9 +1846,10 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         )
 
     def _loopfs_helper_path(self) -> Path | None:
-        """Return installed privileged helper path if available."""
-        if LOOPFS_HELPER_PATH.is_file():
-            return LOOPFS_HELPER_PATH
+        """Return the preferred or legacy privileged helper when executable."""
+        for candidate in (LOOPFS_HELPER_PATH, LEGACY_LOOPFS_HELPER_PATH):
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return candidate
         return None
 
     def _run_loopfs(self, action: str, *args: Path, timeout: int = 30) -> None:

--- a/src/smolvm/runtime/backends.py
+++ b/src/smolvm/runtime/backends.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from smolvm.exceptions import SmolVMError
+from smolvm.host.paths import find_firecracker
 from smolvm.utils import which  # noqa: F401 — imported for test patching
 
 logger = logging.getLogger(__name__)
@@ -36,10 +37,6 @@ BACKEND_AUTO = "auto"
 
 SUPPORTED_BACKENDS = {BACKEND_FIRECRACKER, BACKEND_QEMU, BACKEND_LIBKRUN, BACKEND_VZ}
 
-# Where ``smolvm`` installs a private Firecracker binary when it isn't on PATH.
-# Kept in sync with ``smolvm.host.manager.HostManager.BIN_DIR``; duplicated here
-# so backend selection stays free of the heavier host-manager import.
-_LOCAL_BIN_DIR = Path.home() / ".smolvm" / "bin"
 _KVM_DEVICE = Path("/dev/kvm")
 
 
@@ -73,11 +70,8 @@ def _qemu_system_candidates() -> tuple[str, ...]:
 
 
 def _firecracker_binary_present() -> bool:
-    """Return whether a Firecracker binary is on ``PATH`` or in ``~/.smolvm/bin``."""
-    if which("firecracker") is not None:
-        return True
-    local = _LOCAL_BIN_DIR / "firecracker"
-    return local.exists() and os.access(local, os.X_OK)
+    """Return whether the configured Firecracker binary is executable."""
+    return find_firecracker(path_lookup=which) is not None
 
 
 def _kvm_accessible() -> bool:
@@ -328,8 +322,7 @@ def _create_with_qemu_command(vm_name: str | None) -> str:
 def _firecracker_missing_message(vm_name: str | None = None) -> str:
     """Plain-English recovery for a missing Firecracker binary."""
     return (
-        "Firecracker isn't installed on this machine. Install it and make sure "
-        "the 'firecracker' binary is on your PATH (or in ~/.smolvm/bin), or "
+        "Firecracker isn't installed on this machine. Run 'smolvm setup', or "
         f"create the sandbox with a different backend, e.g. '{_create_with_qemu_command(vm_name)}'."
     )
 

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -3377,8 +3377,7 @@ class SmolVMManager:
         fc_path = self.host.find_firecracker()
         if fc_path is None:
             raise SmolVMError(
-                "Firecracker binary not found. "
-                "Install it with: smolvm.host.manager.HostManager().install_firecracker()"
+                "Firecracker isn't installed; run 'smolvm setup', then start the sandbox again."
             )
 
         cmd = [str(fc_path), "--api-sock", str(socket_path)]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,4 +1,5 @@
 import contextlib
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -257,3 +258,30 @@ def test_firecracker_available_needs_binary_and_kvm() -> None:
         assert b.firecracker_available() is False
     with _env(fc_binary=True, kvm=True):
         assert b.firecracker_available() is True
+
+
+def test_firecracker_probe_honors_configured_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary = tmp_path / "firecracker"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    monkeypatch.setenv("SMOLVM_FIRECRACKER_DIR", str(tmp_path))
+    monkeypatch.setattr(b, "which", lambda _name: None)
+
+    assert b._firecracker_binary_present() is True
+
+
+def test_missing_configured_firecracker_does_not_fall_back_to_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path_binary = tmp_path / "path" / "firecracker"
+    path_binary.parent.mkdir()
+    path_binary.write_text("#!/bin/sh\n")
+    path_binary.chmod(0o755)
+    monkeypatch.setenv("SMOLVM_FIRECRACKER_DIR", str(tmp_path / "missing"))
+    monkeypatch.setattr(b, "which", lambda _name: path_binary)
+
+    assert b._firecracker_binary_present() is False

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -221,6 +221,31 @@ class TestDockerDiagnostics:
 class TestImageBuilderLoopFs:
     """Tests for image builder loopfs helper integration."""
 
+    def test_loopfs_helper_prefers_new_root_controlled_path(self, tmp_path: Path) -> None:
+        preferred = tmp_path / "var" / "smolvm-loopfs-helper"
+        legacy = tmp_path / "usr-local" / "smolvm-loopfs-helper"
+        for helper in (preferred, legacy):
+            helper.parent.mkdir(parents=True)
+            helper.touch(mode=0o755)
+
+        with (
+            patch.object(builder_mod, "LOOPFS_HELPER_PATH", preferred),
+            patch.object(builder_mod, "LEGACY_LOOPFS_HELPER_PATH", legacy),
+        ):
+            assert ImageBuilder(cache_dir=tmp_path / "images")._loopfs_helper_path() == preferred
+
+    def test_loopfs_helper_uses_legacy_path_during_migration(self, tmp_path: Path) -> None:
+        preferred = tmp_path / "missing"
+        legacy = tmp_path / "legacy" / "smolvm-loopfs-helper"
+        legacy.parent.mkdir()
+        legacy.touch(mode=0o755)
+
+        with (
+            patch.object(builder_mod, "LOOPFS_HELPER_PATH", preferred),
+            patch.object(builder_mod, "LEGACY_LOOPFS_HELPER_PATH", legacy),
+        ):
+            assert ImageBuilder(cache_dir=tmp_path / "images")._loopfs_helper_path() == legacy
+
     def test_run_loopfs_missing_helper_raises(self, tmp_path: Path) -> None:
         builder = ImageBuilder(cache_dir=tmp_path / "images")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2588,7 +2588,7 @@ class TestCliSetup:
 
         assert ret == 0
         output = "".join(capsys.readouterr().out.split())
-        assert f"SMOLVM_FIRECRACKER_DIR={selected}" in output
+        assert f"runexportSMOLVM_FIRECRACKER_DIR={selected}" in output
 
     @patch("smolvm.cli.commands.options.platform.system", return_value="Linux")
     def test_setup_remove_runtime_config_rejects_firecracker_dir(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2496,6 +2496,7 @@ class TestCliSetup:
         assert "--runtime-user" not in help_text
         assert "--remove-runtime-config" not in help_text
         assert "--no-configure-runtime" not in help_text
+        assert "--firecracker-dir" not in help_text
         # Cross-platform flags should still appear
         assert "--skip-deps" in help_text
 
@@ -2548,6 +2549,66 @@ class TestCliSetup:
         assert ret == 0
         options = mock_run_setup.call_args.args[0]
         assert options.firecracker_version == "v1.15.0"
+
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_firecracker_dir_forwarded(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``--firecracker-dir`` should populate SetupOptions."""
+        mock_run_setup.return_value = 0
+        selected = tmp_path / "firecracker"
+
+        ret = main(["setup", "--firecracker-dir", str(selected)])
+
+        assert ret == 0
+        options = mock_run_setup.call_args.args[0]
+        assert options.firecracker_dir == selected
+
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_custom_firecracker_dir_warns_when_not_discoverable(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A one-shot custom folder should name the persistent environment setting."""
+        mock_run_setup.return_value = 0
+        selected = tmp_path / "not-on-path"
+        monkeypatch.delenv("SMOLVM_FIRECRACKER_DIR", raising=False)
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        ret = main(["setup", "--firecracker-dir", str(selected)])
+
+        assert ret == 0
+        output = "".join(capsys.readouterr().out.split())
+        assert f"SMOLVM_FIRECRACKER_DIR={selected}" in output
+
+    @patch("smolvm.cli.commands.options.platform.system", return_value="Linux")
+    def test_setup_remove_runtime_config_rejects_firecracker_dir(
+        self,
+        mock_platform_system: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Runtime-policy removal should reject installation options."""
+        ret = main(
+            [
+                "setup",
+                "--remove-runtime-config",
+                "--firecracker-dir",
+                str(tmp_path),
+            ]
+        )
+
+        assert ret == 2
+        assert "not allowed with --firecracker-dir" in capsys.readouterr().err
 
     @patch("smolvm.cli.main.platform.system", return_value="Linux")
     @patch("smolvm.host.setup.run_setup")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -77,6 +77,56 @@ class TestDoctorFirecracker:
         assert report.failures == []
         assert report.warnings == []
 
+    def test_missing_configured_firecracker_names_exact_recovery(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A configured folder should appear in the doctor failure and fix."""
+        configured = tmp_path / "custom firecracker"
+        monkeypatch.setenv("SMOLVM_FIRECRACKER_DIR", str(configured))
+        mock_host = MagicMock()
+        mock_host.find_firecracker.return_value = None
+
+        with (
+            patch("smolvm.host.doctor.HostManager", return_value=mock_host),
+            patch("smolvm.host.doctor._check_kvm_runtime", return_value=_pass("kvm")),
+            patch(
+                "smolvm.host.doctor._check_kvm_permissions",
+                return_value=_pass("worker:kvm-permissions"),
+            ),
+            patch(
+                "smolvm.host.doctor._check_kvm_nx_huge_pages",
+                return_value=_pass("worker:kvm-nx-huge-pages"),
+            ),
+            patch(
+                "smolvm.host.doctor._check_thp_disabled",
+                return_value=_pass("worker:thp-disabled"),
+            ),
+            patch(
+                "smolvm.host.doctor._check_ksm_disabled",
+                return_value=_pass("worker:ksm-disabled"),
+            ),
+            patch(
+                "smolvm.host.doctor._check_swap_disabled",
+                return_value=_pass("worker:swap-disabled"),
+            ),
+            patch("smolvm.host.doctor.check_network_prerequisites", return_value=[]),
+            patch(
+                "smolvm.host.doctor.which",
+                side_effect=lambda binary: Path(f"/usr/bin/{binary}"),
+            ),
+            patch("smolvm.host.doctor.run_command", return_value=MagicMock(stdout="")),
+        ):
+            report = generate_doctor_report(backend="firecracker")
+
+        firecracker = next(check for check in report.checks if check.name == "firecracker")
+        assert firecracker.status == "fail"
+        assert str(configured / "firecracker") in firecracker.detail
+        assert firecracker.fix is not None
+        assert "smolvm setup --firecracker-dir" in firecracker.fix
+        assert str(configured) in firecracker.fix
+
     @patch("smolvm.host.doctor._check_kvm_runtime", new=lambda: _pass("kvm"))
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
     @patch(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -15,6 +15,7 @@
 """Tests for SmolVM doctor diagnostics."""
 
 import json
+import shlex
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -123,9 +124,9 @@ class TestDoctorFirecracker:
         firecracker = next(check for check in report.checks if check.name == "firecracker")
         assert firecracker.status == "fail"
         assert str(configured / "firecracker") in firecracker.detail
-        assert firecracker.fix is not None
-        assert "smolvm setup --firecracker-dir" in firecracker.fix
-        assert str(configured) in firecracker.fix
+        assert firecracker.fix == (
+            f"Run smolvm setup --firecracker-dir {shlex.quote(str(configured))}."
+        )
 
     @patch("smolvm.host.doctor._check_kvm_runtime", new=lambda: _pass("kvm"))
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -104,12 +104,20 @@ class TestCheckDependencies:
 class TestFindFirecracker:
     """Tests for finding the Firecracker binary."""
 
-    @patch("smolvm.host.manager.which", return_value=Path("/usr/local/bin/firecracker"))
-    def test_found_in_path(self, mock_which: MagicMock, host_manager: HostManager) -> None:
-        """Test finding firecracker in system PATH."""
-        result = host_manager.find_firecracker()
+    @patch("smolvm.host.manager.which")
+    def test_found_in_path(
+        self,
+        mock_which: MagicMock,
+        host_manager: HostManager,
+        tmp_path: Path,
+    ) -> None:
+        """Test finding an executable Firecracker in system PATH."""
+        binary = tmp_path / "firecracker"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mock_which.return_value = binary
 
-        assert result == Path("/usr/local/bin/firecracker")
+        assert host_manager.find_firecracker() == binary
 
     @patch("smolvm.host.manager.os.access", return_value=True)
     @patch("smolvm.host.manager.which", return_value=None)
@@ -121,25 +129,19 @@ class TestFindFirecracker:
         tmp_path: Path,
     ) -> None:
         """Test finding firecracker in ~/.smolvm/bin/."""
-        # Override BIN_DIR to use tmp_path
-        host_manager.BIN_DIR = tmp_path / "bin"
-        host_manager.BIN_DIR.mkdir(parents=True)
-        fc_binary = host_manager.BIN_DIR / "firecracker"
-        fc_binary.touch()
+        host_manager = HostManager(firecracker_dir=tmp_path / "bin")
+        host_manager.firecracker_dir.mkdir(parents=True)
+        fc_binary = host_manager.firecracker_dir / "firecracker"
+        fc_binary.touch(mode=0o755)
 
-        result = host_manager.find_firecracker()
-
-        assert result == fc_binary
+        assert host_manager.find_firecracker() == fc_binary
 
     @patch("smolvm.host.manager.which", return_value=None)
     def test_not_found(self, mock_which: MagicMock, host_manager: HostManager) -> None:
         """Test when firecracker is not found anywhere."""
-        # BIN_DIR default points to ~/.smolvm/bin which doesn't have it
-        host_manager.BIN_DIR = Path("/nonexistent/dir")
+        host_manager = HostManager(firecracker_dir=Path("/nonexistent/dir"))
 
-        result = host_manager.find_firecracker()
-
-        assert result is None
+        assert host_manager.find_firecracker() is None
 
 
 class TestInstallFirecracker:
@@ -163,8 +165,7 @@ class TestInstallFirecracker:
         tmp_path: Path,
     ) -> None:
         """Test successful firecracker installation."""
-        # Override paths
-        host_manager.BIN_DIR = tmp_path / "bin"
+        host_manager = HostManager(firecracker_dir=tmp_path / "bin")
 
         # Create a fake tarball with a firecracker binary inside
         version = DEFAULT_FIRECRACKER_VERSION
@@ -229,7 +230,7 @@ class TestValidate:
         host_manager: HostManager,
     ) -> None:
         """Test validation when nothing is available."""
-        host_manager.BIN_DIR = Path("/nonexistent")
+        host_manager = HostManager(firecracker_dir=Path("/nonexistent"))
 
         info = host_manager.validate()
 
@@ -250,6 +251,11 @@ class TestHostManagerInit:
         """Test custom Firecracker version."""
         hm = HostManager(firecracker_version="v1.13.0")
         assert hm.firecracker_version == "v1.13.0"
+
+    def test_explicit_firecracker_dir(self, tmp_path: Path) -> None:
+        """An explicit Firecracker folder should override the default."""
+        hm = HostManager(firecracker_dir=tmp_path)
+        assert hm.firecracker_dir == tmp_path.resolve()
 
     def test_empty_version_raises(self) -> None:
         """Test that empty version raises ValueError."""

--- a/tests/test_host_paths.py
+++ b/tests/test_host_paths.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Firecracker installation and discovery paths."""
+
+from pathlib import Path
+
+import pytest
+
+from smolvm.host.paths import (
+    SMOLVM_FIRECRACKER_DIR_ENV,
+    directory_is_on_path,
+    find_firecracker,
+    resolve_firecracker_dir,
+)
+
+
+def _executable(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    binary = directory / "firecracker"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    return binary
+
+
+def test_explicit_directory_beats_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, str(tmp_path / "environment"))
+
+    assert resolve_firecracker_dir(tmp_path / "explicit") == (tmp_path / "explicit").resolve()
+
+
+def test_environment_beats_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    configured = tmp_path / "configured"
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, str(configured))
+
+    assert resolve_firecracker_dir() == configured.resolve()
+
+
+def test_empty_environment_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, "   ")
+
+    with pytest.raises(ValueError, match="SMOLVM_FIRECRACKER_DIR cannot be empty"):
+        resolve_firecracker_dir()
+
+
+def test_relative_explicit_directory_becomes_absolute(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert resolve_firecracker_dir(Path("runtime/bin")) == (tmp_path / "runtime/bin").resolve()
+
+
+def test_configured_directory_is_authoritative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path_binary = _executable(tmp_path / "path")
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, str(tmp_path / "missing"))
+
+    assert find_firecracker(path_lookup=lambda _name: path_binary) is None
+
+
+def test_path_is_used_before_user_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path_binary = _executable(tmp_path / "path")
+    monkeypatch.delenv(SMOLVM_FIRECRACKER_DIR_ENV, raising=False)
+
+    assert find_firecracker(path_lookup=lambda _name: path_binary) == path_binary.resolve()
+
+
+def test_environment_changes_are_observed_after_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _executable(tmp_path / "first")
+    second = _executable(tmp_path / "second")
+
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, str(first.parent))
+    assert find_firecracker(path_lookup=lambda _name: None) == first
+
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, str(second.parent))
+    assert find_firecracker(path_lookup=lambda _name: None) == second
+
+
+def test_non_executable_file_is_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured = tmp_path / "configured"
+    configured.mkdir()
+    (configured / "firecracker").write_text("not executable")
+    monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, str(configured))
+
+    assert find_firecracker(path_lookup=lambda _name: None) is None
+
+
+def test_directory_is_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    configured = tmp_path / "path with spaces"
+    configured.mkdir()
+    monkeypatch.setenv("PATH", f"/usr/bin:{configured}")
+
+    assert directory_is_on_path(configured) is True
+    assert directory_is_on_path(tmp_path / "elsewhere") is False

--- a/tests/test_host_paths.py
+++ b/tests/test_host_paths.py
@@ -53,8 +53,13 @@ def test_environment_beats_default(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 def test_empty_environment_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(SMOLVM_FIRECRACKER_DIR_ENV, "   ")
 
-    with pytest.raises(ValueError, match="SMOLVM_FIRECRACKER_DIR cannot be empty"):
+    with pytest.raises(ValueError) as exc_info:
         resolve_firecracker_dir()
+
+    message = str(exc_info.value)
+    assert "SMOLVM_FIRECRACKER_DIR is empty" in message
+    assert "unset SMOLVM_FIRECRACKER_DIR" in message
+    assert "smolvm setup" in message
 
 
 def test_relative_explicit_directory_becomes_absolute(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -262,6 +262,51 @@ class TestBuildSetupCommand:
             "v1.15.0",
         ]
 
+    def test_linux_firecracker_dir_forwarded_as_absolute_path(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+        selected = tmp_path / "path with spaces"
+
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(firecracker_dir=selected),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command[-2:] == ["--firecracker-dir", str(selected.resolve())]
+
+    def test_linux_firecracker_dir_reads_environment(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        asset_root = _make_asset_root(tmp_path)
+        selected = tmp_path / "environment"
+        monkeypatch.setenv("SMOLVM_FIRECRACKER_DIR", str(selected))
+
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command[-2:] == ["--firecracker-dir", str(selected.resolve())]
+
+    def test_linux_relative_firecracker_dir_resolves_before_bash(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        asset_root = _make_asset_root(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(firecracker_dir=Path("runtime/bin")),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command[-2:] == ["--firecracker-dir", str((tmp_path / "runtime/bin").resolve())]
+
     def test_macos_ignores_linux_only_bake_flags(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 

--- a/tests/test_setup_scripts.py
+++ b/tests/test_setup_scripts.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Portable regression tests for the packaged Linux setup scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_INSTALL_SCRIPT = _REPO_ROOT / "scripts" / "internal" / "install-firecracker.sh"
+_SYSTEM_SETUP_SCRIPT = _REPO_ROOT / "scripts" / "system-setup.sh"
+_ONE_LINE_INSTALLER = _REPO_ROOT / "scripts" / "install.sh"
+_RUNTIME_CONFIG_SCRIPT = _REPO_ROOT / "scripts" / "internal" / "configure-runtime-sudoers.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def _fake_download_tools(tmp_path: Path) -> Path:
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    _write_executable(
+        tools / "uname",
+        '#!/bin/bash\n[[ "$1" == "-m" ]] && echo x86_64 || /usr/bin/uname "$@"\n',
+    )
+    _write_executable(
+        tools / "wget",
+        """#!/bin/bash
+set -eu
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-O" ]]; then
+        : > "$2"
+        exit 0
+    fi
+    shift
+done
+exit 1
+""",
+    )
+    _write_executable(
+        tools / "tar",
+        """#!/bin/bash
+set -eu
+if [[ "${FAIL_FAKE_TAR:-}" == "1" ]]; then
+    exit 2
+fi
+destination=""
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-C" ]]; then
+        destination="$2"
+        shift 2
+        continue
+    fi
+    shift
+done
+release="$destination/release-v1.14.1-x86_64"
+mkdir -p "$release"
+cat > "$release/firecracker-v1.14.1-x86_64" <<'EOF'
+#!/bin/sh
+echo 'Firecracker v1.14.1'
+EOF
+chmod 755 "$release/firecracker-v1.14.1-x86_64"
+""",
+    )
+    return tools
+
+
+def _run_installer(
+    destination: Path,
+    tools: Path,
+    *,
+    fail_tar: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{tools}{os.pathsep}{env['PATH']}"
+    if fail_tar:
+        env["FAIL_FAKE_TAR"] = "1"
+    return subprocess.run(
+        [
+            "bash",
+            str(_INSTALL_SCRIPT),
+            "--skip-deps",
+            "--firecracker-dir",
+            str(destination),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_installer_supports_custom_directory_with_spaces(tmp_path: Path) -> None:
+    tools = _fake_download_tools(tmp_path)
+    destination = tmp_path / "custom runtime" / "bin"
+
+    result = _run_installer(destination, tools)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    binary = destination / "firecracker"
+    assert binary.is_file()
+    assert os.access(binary, os.X_OK)
+    assert "Firecracker v1.14.1" in subprocess.check_output([binary], text=True)
+
+
+def test_failed_reinstall_preserves_existing_binary(tmp_path: Path) -> None:
+    tools = _fake_download_tools(tmp_path)
+    destination = tmp_path / "bin"
+    destination.mkdir()
+    binary = destination / "firecracker"
+    binary.write_text("#!/bin/sh\necho existing\n")
+    binary.chmod(0o755)
+
+    result = _run_installer(destination, tools, fail_tar=True)
+
+    assert result.returncode != 0
+    assert binary.read_text() == "#!/bin/sh\necho existing\n"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [_INSTALL_SCRIPT, _SYSTEM_SETUP_SCRIPT, _ONE_LINE_INSTALLER, _RUNTIME_CONFIG_SCRIPT],
+)
+def test_changed_setup_scripts_have_valid_bash_syntax(script: Path) -> None:
+    subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_firecracker_installer_has_no_system_destination_or_jailer_state() -> None:
+    text = _INSTALL_SCRIPT.read_text() + _SYSTEM_SETUP_SCRIPT.read_text()
+
+    assert "/usr/local/bin/firecracker" not in text
+    assert "/usr/local/bin/jailer" not in text
+    assert "/srv/jailer" not in text
+    assert "groupadd -g 2000 firecracker" not in text
+
+
+def test_system_setup_handles_fedora_without_assuming_apt() -> None:
+    text = _SYSTEM_SETUP_SCRIPT.read_text()
+
+    assert "/run/ostree-booted" in text
+    assert "rpm-ostree install" in text
+    assert "dnf install" in text
+    assert "Host dependencies already installed" in text
+
+
+def test_one_line_installer_keeps_custom_directory_for_doctor() -> None:
+    text = _ONE_LINE_INSTALLER.read_text()
+
+    assert "FIRECRACKER_DIR_ARG" in text
+    assert 'export SMOLVM_FIRECRACKER_DIR="${FIRECRACKER_DIR_ARG}"' in text
+    assert 'smolvm setup --skip-deps "${SETUP_ARGS[@]}"' in text
+
+
+def test_runtime_sudo_policy_excludes_user_writable_programs() -> None:
+    text = _RUNTIME_CONFIG_SCRIPT.read_text()
+
+    assert 'LOOPFS_HELPER_DIR="/var/lib/smolvm/libexec"' in text
+    assert "SMOLVM_VM_CMDS" not in text
+    assert "FIRECRACKER_BIN" not in text
+    assert "kill -9" not in text
+    assert "SMOLVM_FIRECRACKER_DIR" not in text

--- a/tests/test_setup_scripts.py
+++ b/tests/test_setup_scripts.py
@@ -88,19 +88,23 @@ def _run_installer(
     tools: Path,
     *,
     fail_tar: bool = False,
+    runtime_user: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PATH"] = f"{tools}{os.pathsep}{env['PATH']}"
     if fail_tar:
         env["FAIL_FAKE_TAR"] = "1"
+    args = [
+        "bash",
+        str(_INSTALL_SCRIPT),
+        "--skip-deps",
+        "--firecracker-dir",
+        str(destination),
+    ]
+    if runtime_user is not None:
+        args.extend(["--runtime-user", runtime_user])
     return subprocess.run(
-        [
-            "bash",
-            str(_INSTALL_SCRIPT),
-            "--skip-deps",
-            "--firecracker-dir",
-            str(destination),
-        ],
+        args,
         env=env,
         capture_output=True,
         text=True,
@@ -118,7 +122,22 @@ def test_installer_supports_custom_directory_with_spaces(tmp_path: Path) -> None
     binary = destination / "firecracker"
     assert binary.is_file()
     assert os.access(binary, os.X_OK)
-    assert "Firecracker v1.14.1" in subprocess.check_output([binary], text=True)
+    version_output = subprocess.check_output([binary], text=True)
+    assert "Firecracker v1.14.1" in version_output
+
+
+def test_explicit_directory_does_not_require_runtime_user_home(tmp_path: Path) -> None:
+    if subprocess.run(["id", "nobody"], check=False, capture_output=True).returncode != 0:
+        pytest.skip("test requires the standard nobody account")
+
+    tools = _fake_download_tools(tmp_path)
+    _write_executable(tools / "getent", "#!/bin/sh\nexit 1\n")
+    destination = tmp_path / "explicit" / "bin"
+
+    result = _run_installer(destination, tools, runtime_user="nobody")
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert (destination / "firecracker").is_file()
 
 
 def test_failed_reinstall_preserves_existing_binary(tmp_path: Path) -> None:
@@ -173,7 +192,14 @@ def test_runtime_sudo_policy_excludes_user_writable_programs() -> None:
     text = _RUNTIME_CONFIG_SCRIPT.read_text()
 
     assert 'LOOPFS_HELPER_DIR="/var/lib/smolvm/libexec"' in text
+    assert '[[ -L "${LOOPFS_HELPER_DST}"' in text
     assert "SMOLVM_VM_CMDS" not in text
     assert "FIRECRACKER_BIN" not in text
     assert "kill -9" not in text
     assert "SMOLVM_FIRECRACKER_DIR" not in text
+
+
+def test_setup_recovery_shell_quotes_custom_firecracker_directory() -> None:
+    text = _SYSTEM_SETUP_SCRIPT.read_text()
+
+    assert "printf -v firecracker_dir_arg '%q'" in text

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1581,6 +1581,18 @@ class TestDataDirResolution:
 class TestFirecrackerLaunchAndSocketCleanup:
     """Tests for Firecracker launch mode and socket cleanup behavior."""
 
+    def test_missing_firecracker_uses_public_setup_recovery(
+        self,
+        smol_vm: SmolVMManager,
+        tmp_path: Path,
+    ) -> None:
+        """Missing Firecracker errors should point to the public setup command."""
+        with (
+            patch.object(smol_vm.host, "find_firecracker", return_value=None),
+            pytest.raises(SmolVMError, match="smolvm setup"),
+        ):
+            smol_vm._start_firecracker(tmp_path / "fc.sock", tmp_path / "fc.log")
+
     def test_start_firecracker_runs_without_sudo(
         self, smol_vm: SmolVMManager, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- add `smolvm setup --firecracker-dir` and `SMOLVM_FIRECRACKER_DIR`, backed by shared Firecracker discovery
- install Firecracker atomically in the invoking user's `~/.smolvm/bin` by default while preserving PATH-based installations
- remove unused Jailer setup and Firecracker/root-kill sudo grants, and keep the loopfs helper in a root-owned location
- add Fedora/dnf and rpm-ostree-aware dependency handling, documentation, and regression coverage

## Related Issues

- Closes #479

## Testing

- `uv run pytest tests/test_host_paths.py tests/test_host.py tests/test_backends.py tests/test_setup.py tests/test_cli.py::TestCliSetup tests/test_doctor.py tests/test_build.py::TestImageBuilderLoopFs tests/test_setup_scripts.py tests/test_vm.py::TestFirecrackerLaunchAndSocketCleanup -q` (125 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/smolvm/host/paths.py src/smolvm/runtime/backends.py`
- `shellcheck` and `bash -n` on the changed setup scripts
- packaged-wheel asset verification
- Debian container smoke tests for custom/default destinations, repeated setup, invoking-user ownership, and sudo policy
- simulated rpm-ostree host check confirming setup reports the explicit `rpm-ostree` recovery command without invoking `apt-get`

The full local suite reached 2,042 passed, 19 skipped, and 30 deselected. Its 12 failures are existing macOS environment failures involving Bash completion selection, APFS sparse-file accounting, and a stale native extension; representative completion and sparse-file failures reproduce on `origin/main`.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux users can choose a custom Firecracker installation directory with `smolvm setup --firecracker-dir` or `SMOLVM_FIRECRACKER_DIR`.
  * Firecracker discovery supports configured directories, system `PATH`, and per-user defaults.
  * Installation supports apt, dnf, and Fedora Atomic environments.

* **Bug Fixes**
  * Improved setup and diagnostic messages provide actionable commands and configured paths.
  * Runtime helper installation now uses a protected location while retaining legacy compatibility.

* **Documentation**
  * Added guidance for storage configuration, custom Firecracker locations, environment variables, and reboot requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->