### PR TITLE
fix(tests): make the suite pass on macOS

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,14 +14,27 @@ permissions:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.13", "3.14"]
+        # One macOS leg rather than the full cross-product: macOS runners are
+        # slower to schedule, and a single job is enough to catch an assertion
+        # that only holds on Linux. macOS is the first OS in the package
+        # classifiers and CONTRIBUTING.md documents it as a dev platform, but
+        # the suite had never run on it.
+        include:
+          # `label` is undefined on the ubuntu legs, so it renders empty and their
+          # existing check names are untouched -- required status checks and the
+          # merge queue gate on those names.
+          - os: macos-latest
+            python-version: "3.14"
+            label: ", macOS"
 
-    name: pytest (Python ${{ matrix.python-version }})
+    name: pytest (Python ${{ matrix.python-version }}${{ matrix.label }})
 
     steps:
       - name: Check out repository
@@ -57,13 +70,26 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --python ${{ matrix.python-version }}
 
+      # Netlink is a Linux interface, so HAS_NETLINK is False on macOS by
+      # design. Assert the strong property where it applies; macOS asserts the
+      # portable one below.
       - name: Assert native extension available
+        if: runner.os == 'Linux'
         run: |
           uv run python -c "
           from smolvm.host._accel import HAS_NETLINK
           assert HAS_NETLINK, 'smolvm-core not loaded'
           from smolvm_core import network
           assert network.available(), 'Native extension reports native networking unavailable on Linux'
+          print('smolvm-core: OK')
+          "
+
+      - name: Assert native extension available (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          uv run python -c "
+          from smolvm_core import disk
+          assert disk.available(), 'Native extension reports native disk I/O unavailable'
           print('smolvm-core: OK')
           "
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,38 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 
 import pytest
+
+_SPARSE_TEST_HOLE_BYTES = 32 * 1024 * 1024
+_SPARSE_TEST_FALLBACK_BYTES = 1 * 1024 * 1024
+
+
+@pytest.fixture(scope="session")
+def sparse_test_config(tmp_path_factory: pytest.TempPathFactory) -> tuple[int, bool]:
+    """Adapt sparse-file assertions and fixture sizes to the test volume.
+
+    Some macOS volumes report small files with holes as fully allocated, while
+    volumes without sparse-file support cannot satisfy allocation assertions at
+    any size. Probe the same write-and-seek pattern as the copy fallback. Tests
+    keep their content checks but use smaller fixtures when holes are unavailable.
+    """
+    probe = tmp_path_factory.mktemp("sparse-probe") / "probe.img"
+    with probe.open("wb") as file:
+        first_chunk = b"start" + b"\0" * (_SPARSE_TEST_FALLBACK_BYTES - len(b"start"))
+        file.write(first_chunk)
+        file.seek(_SPARSE_TEST_HOLE_BYTES - len(first_chunk), os.SEEK_CUR)
+        file.write(b"end")
+
+    stat = probe.stat()
+    blocks = getattr(stat, "st_blocks", None)
+    supports_sparse_allocation = blocks is not None and blocks * 512 < stat.st_size
+    hole_bytes = (
+        _SPARSE_TEST_HOLE_BYTES if supports_sparse_allocation else _SPARSE_TEST_FALLBACK_BYTES
+    )
+    return hole_bytes, supports_sparse_allocation
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5344,7 +5344,10 @@ class TestCliCompletion:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """`completion bash --install` persists the script and sources it from ~/.bashrc."""
-        ret = main(["completion", "bash", "--install"])
+        # Pin the platform: ~/.bashrc is the Linux answer, and the macOS answer
+        # has its own test below. Without this the assertion tracks the host.
+        with patch("smolvm.cli.completion.platform.system", return_value="Linux"):
+            ret = main(["completion", "bash", "--install"])
 
         assert ret == 0
         script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
@@ -5356,8 +5359,9 @@ class TestCliCompletion:
 
     def test_completion_install_is_idempotent(self, fake_home: Path) -> None:
         """Re-running --install refreshes the script without duplicating the rc line."""
-        main(["completion", "bash", "--install"])
-        ret = main(["completion", "bash", "--install"])
+        with patch("smolvm.cli.completion.platform.system", return_value="Linux"):
+            main(["completion", "bash", "--install"])
+            ret = main(["completion", "bash", "--install"])
 
         assert ret == 0
         script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
@@ -5418,7 +5422,8 @@ class TestCliCompletion:
         quirky_home.mkdir()
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv("HOME", str(quirky_home))
-            ret = main(["completion", "bash", "--install"])
+            with patch("smolvm.cli.completion.platform.system", return_value="Linux"):
+                ret = main(["completion", "bash", "--install"])
 
         assert ret == 0
         script_path = quirky_home / ".smolvm" / "completions" / "smolvm.bash"
@@ -5531,7 +5536,10 @@ class TestCliCompletion:
         sudo_info.pw_uid = os.getuid()
         sudo_info.pw_gid = os.getgid()
 
-        with patch("smolvm.vm._get_sudo_user_info", return_value=sudo_info):
+        with (
+            patch("smolvm.vm._get_sudo_user_info", return_value=sudo_info),
+            patch("smolvm.cli.completion.platform.system", return_value="Linux"),
+        ):
             ret = main(["completion", "bash", "--install"])
 
         assert ret == 0

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -604,6 +604,15 @@ class TestAliases:
         assert payload["command"] == "image.list"
 
 
+# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
+# map is irrelevant; what decides whether the TARGET ends up sparse is its size
+# on the volume the test runs on. On one macOS volume a written extent below
+# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
+# volumes on the same machine punch holes from 1 MiB. The mechanism is not
+# identified, so treat this as a margin rather than a bound.
+_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
+
+
 def _make_published_entry(root: Path, name: str) -> Path:
     """A realistic published cache dir: kernel, zst, sparse rootfs, sidecar."""
     import hashlib
@@ -612,14 +621,14 @@ def _make_published_entry(root: Path, name: str) -> Path:
 
     d = root / name
     d.mkdir(parents=True)
-    raw = b"\x00" * (1 << 20) + b"REAL-DATA" + b"\x00" * (1 << 20)
+    raw = b"\x00" * _SPARSE_HOLE_BYTES + b"REAL-DATA"
     (d / "rootfs.ext4.zst").write_bytes(zstandard.compress(raw))
     sha = hashlib.sha256((d / "rootfs.ext4.zst").read_bytes()).hexdigest()
     (d / "rootfs.ext4.from-sha256").write_text(f"sparse-v1:{sha}")
     (d / "vmlinux.bin").write_bytes(b"kernel-bytes")
     with open(d / "rootfs.ext4", "wb") as f:
         f.truncate(len(raw))
-        f.seek(1 << 20)
+        f.seek(_SPARSE_HOLE_BYTES)
         f.write(b"REAL-DATA")
     return d
 

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -604,16 +604,12 @@ class TestAliases:
         assert payload["command"] == "image.list"
 
 
-# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
-# map is irrelevant; what decides whether the TARGET ends up sparse is its size
-# on the volume the test runs on. On one macOS volume a written extent below
-# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
-# volumes on the same machine punch holes from 1 MiB. The mechanism is not
-# identified, so treat this as a margin rather than a bound.
-_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
-
-
-def _make_published_entry(root: Path, name: str) -> Path:
+def _make_published_entry(
+    root: Path,
+    name: str,
+    *,
+    hole_bytes: int = 1 * 1024 * 1024,
+) -> Path:
     """A realistic published cache dir: kernel, zst, sparse rootfs, sidecar."""
     import hashlib
 
@@ -621,23 +617,31 @@ def _make_published_entry(root: Path, name: str) -> Path:
 
     d = root / name
     d.mkdir(parents=True)
-    raw = b"\x00" * _SPARSE_HOLE_BYTES + b"REAL-DATA"
+    raw = b"\x00" * hole_bytes + b"REAL-DATA" + b"\x00" * (1 * 1024 * 1024)
     (d / "rootfs.ext4.zst").write_bytes(zstandard.compress(raw))
     sha = hashlib.sha256((d / "rootfs.ext4.zst").read_bytes()).hexdigest()
     (d / "rootfs.ext4.from-sha256").write_text(f"sparse-v1:{sha}")
     (d / "vmlinux.bin").write_bytes(b"kernel-bytes")
     with open(d / "rootfs.ext4", "wb") as f:
         f.truncate(len(raw))
-        f.seek(_SPARSE_HOLE_BYTES)
+        f.seek(hole_bytes)
         f.write(b"REAL-DATA")
     return d
 
 
 class TestImageInspect:
     def test_inspect_exact_name_returns_array(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        sparse_test_config: tuple[int, bool],
     ) -> None:
-        _make_published_entry(tmp_path, "codex-v0.0.1-amd64-firecracker")
+        hole_bytes, supports_sparse_allocation = sparse_test_config
+        _make_published_entry(
+            tmp_path,
+            "codex-v0.0.1-amd64-firecracker",
+            hole_bytes=hole_bytes,
+        )
 
         ret = main(
             [
@@ -665,7 +669,7 @@ class TestImageInspect:
             "vmlinux.bin",
         }
         rootfs = files["rootfs.ext4"]
-        if os.name == "posix":
+        if supports_sparse_allocation:
             assert rootfs["size_on_disk_bytes"] < rootfs["size_bytes"]
         # Stale version: no manifest section.
         assert entry["manifest"] is None

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -29,27 +29,27 @@ import zstandard
 
 from smolvm.cli.main import main
 
-# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
-# map is irrelevant; what decides whether the TARGET ends up sparse is its size
-# on the volume the test runs on. On one macOS volume a written extent below
-# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
-# volumes on the same machine punch holes from 1 MiB. The mechanism is not
-# identified, so treat this as a margin rather than a bound.
-_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
-
-_SPARSE_PAYLOAD = b"\x00" * _SPARSE_HOLE_BYTES + b"REAL-DATA"
+_DEFAULT_HOLE_BYTES = 1 * 1024 * 1024
+_TRAILING_HOLE_BYTES = 1 * 1024 * 1024
+_SPARSE_PAYLOAD = b"\x00" * _DEFAULT_HOLE_BYTES + b"REAL-DATA" + b"\x00" * _TRAILING_HOLE_BYTES
 
 
-def _make_published_entry(root: Path, name: str) -> Path:
+def _make_published_entry(
+    root: Path,
+    name: str,
+    *,
+    hole_bytes: int = _DEFAULT_HOLE_BYTES,
+) -> Path:
+    payload = b"\x00" * hole_bytes + b"REAL-DATA" + b"\x00" * _TRAILING_HOLE_BYTES
     d = root / name
     d.mkdir(parents=True)
-    (d / "rootfs.ext4.zst").write_bytes(zstandard.compress(_SPARSE_PAYLOAD))
+    (d / "rootfs.ext4.zst").write_bytes(zstandard.compress(payload))
     sha = hashlib.sha256((d / "rootfs.ext4.zst").read_bytes()).hexdigest()
     (d / "rootfs.ext4.from-sha256").write_text(f"sparse-v1:{sha}")
     (d / "vmlinux.bin").write_bytes(b"kernel-bytes")
     with open(d / "rootfs.ext4", "wb") as f:
-        f.truncate(len(_SPARSE_PAYLOAD))
-        f.seek(_SPARSE_HOLE_BYTES)
+        f.truncate(len(payload))
+        f.seek(hole_bytes)
         f.write(b"REAL-DATA")
     return d
 
@@ -74,10 +74,18 @@ def _write_archive(
 
 class TestSaveLoadRoundTrip:
     def test_published_entry_round_trips(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        sparse_test_config: tuple[int, bool],
     ) -> None:
+        hole_bytes, supports_sparse_allocation = sparse_test_config
         src = tmp_path / "src"
-        entry = _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        entry = _make_published_entry(
+            src,
+            "codex-v0.0.1-amd64-firecracker",
+            hole_bytes=hole_bytes,
+        )
         archive = tmp_path / "codex.tar"
 
         ret = main(
@@ -115,10 +123,12 @@ class TestSaveLoadRoundTrip:
         ).read_text()
         # Rootfs content intact and holes restored.
         with open(loaded / "rootfs.ext4", "rb") as f:
-            f.seek(_SPARSE_HOLE_BYTES)
+            f.seek(hole_bytes)
             assert f.read(9) == b"REAL-DATA"
+            f.seek(-_TRAILING_HOLE_BYTES, os.SEEK_END)
+            assert f.read() == b"\x00" * _TRAILING_HOLE_BYTES
         st = os.stat(loaded / "rootfs.ext4")
-        if getattr(st, "st_blocks", None) is not None:
+        if supports_sparse_allocation:
             assert st.st_blocks * 512 < st.st_size
 
     def test_custom_entry_round_trips(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -29,7 +29,15 @@ import zstandard
 
 from smolvm.cli.main import main
 
-_SPARSE_PAYLOAD = b"\x00" * (1 << 20) + b"REAL-DATA" + b"\x00" * (1 << 20)
+# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
+# map is irrelevant; what decides whether the TARGET ends up sparse is its size
+# on the volume the test runs on. On one macOS volume a written extent below
+# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
+# volumes on the same machine punch holes from 1 MiB. The mechanism is not
+# identified, so treat this as a margin rather than a bound.
+_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
+
+_SPARSE_PAYLOAD = b"\x00" * _SPARSE_HOLE_BYTES + b"REAL-DATA"
 
 
 def _make_published_entry(root: Path, name: str) -> Path:
@@ -41,7 +49,7 @@ def _make_published_entry(root: Path, name: str) -> Path:
     (d / "vmlinux.bin").write_bytes(b"kernel-bytes")
     with open(d / "rootfs.ext4", "wb") as f:
         f.truncate(len(_SPARSE_PAYLOAD))
-        f.seek(1 << 20)
+        f.seek(_SPARSE_HOLE_BYTES)
         f.write(b"REAL-DATA")
     return d
 
@@ -107,7 +115,7 @@ class TestSaveLoadRoundTrip:
         ).read_text()
         # Rootfs content intact and holes restored.
         with open(loaded / "rootfs.ext4", "rb") as f:
-            f.seek(1 << 20)
+            f.seek(_SPARSE_HOLE_BYTES)
             assert f.read(9) == b"REAL-DATA"
         st = os.stat(loaded / "rootfs.ext4")
         if getattr(st, "st_blocks", None) is not None:

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -928,15 +928,6 @@ class TestBundledManifest:
             )
 
 
-# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
-# map is irrelevant; what decides whether the TARGET ends up sparse is its size
-# on the volume the test runs on. On one macOS volume a written extent below
-# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
-# volumes on the same machine punch holes from 1 MiB. The mechanism is not
-# identified, so treat this as a margin rather than a bound.
-_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
-
-
 class TestDecompressZstd:
     """Direct tests for the streaming decompressor."""
 
@@ -992,11 +983,16 @@ class TestDecompressZstd:
         assert not list(tmp_path.glob("*.partial"))
         assert not list(tmp_path.glob("*.partial.tmp"))
 
-    def test_decompress_zstd_preserves_sparse_zero_ranges(self, tmp_path: Path) -> None:
+    def test_decompress_zstd_preserves_sparse_zero_ranges(
+        self,
+        tmp_path: Path,
+        sparse_test_config: tuple[int, bool],
+    ) -> None:
         """Published raw ext4 caches should keep large zero regions sparse."""
         import zstandard
 
-        plain = b"start" + (b"\0" * _SPARSE_HOLE_BYTES) + b"end"
+        hole_bytes, supports_sparse_allocation = sparse_test_config
+        plain = b"start" + (b"\0" * hole_bytes) + b"end"
         src = tmp_path / "rootfs.ext4.zst"
         src.write_bytes(zstandard.ZstdCompressor(level=3).compress(plain))
         dst = tmp_path / "rootfs.ext4"
@@ -1004,7 +1000,8 @@ class TestDecompressZstd:
         _decompress_zstd(src, dst)
 
         assert dst.read_bytes() == plain
-        assert dst.stat().st_blocks * 512 < dst.stat().st_size
+        if supports_sparse_allocation:
+            assert dst.stat().st_blocks * 512 < dst.stat().st_size
 
     def test_corrupted_input_cleans_up_tmp_file(self, tmp_path: Path) -> None:
         """A failed decompress must not leave a half-written ``.tmp`` behind."""

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -928,6 +928,15 @@ class TestBundledManifest:
             )
 
 
+# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
+# map is irrelevant; what decides whether the TARGET ends up sparse is its size
+# on the volume the test runs on. On one macOS volume a written extent below
+# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
+# volumes on the same machine punch holes from 1 MiB. The mechanism is not
+# identified, so treat this as a margin rather than a bound.
+_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
+
+
 class TestDecompressZstd:
     """Direct tests for the streaming decompressor."""
 
@@ -987,7 +996,7 @@ class TestDecompressZstd:
         """Published raw ext4 caches should keep large zero regions sparse."""
         import zstandard
 
-        plain = b"start" + (b"\0" * (4 * 1024 * 1024)) + b"end"
+        plain = b"start" + (b"\0" * _SPARSE_HOLE_BYTES) + b"end"
         src = tmp_path / "rootfs.ext4.zst"
         src.write_bytes(zstandard.ZstdCompressor(level=3).compress(plain))
         dst = tmp_path / "rootfs.ext4"

--- a/tests/test_smolvm_core.py
+++ b/tests/test_smolvm_core.py
@@ -166,10 +166,19 @@ def test_production_code_does_not_import_private_core_extension() -> None:
     assert offenders == []
 
 
+# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
+# map is irrelevant; what decides whether the TARGET ends up sparse is its size
+# on the volume the test runs on. On one macOS volume a written extent below
+# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
+# volumes on the same machine punch holes from 1 MiB. The mechanism is not
+# identified, so treat this as a margin rather than a bound.
+_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
+
+
 def _write_sparse_file(path: Path) -> None:
     with path.open("wb") as file:
         file.write(b"start")
-        file.seek(4 * 1024 * 1024)
+        file.seek(_SPARSE_HOLE_BYTES)
         file.write(b"end")
 
 
@@ -190,7 +199,7 @@ def test_native_clone_or_sparse_copy_preserves_sparse_holes(tmp_path: Path) -> N
     assert target.stat().st_size == source.stat().st_size
     with target.open("rb") as file:
         assert file.read(5) == b"start"
-        file.seek(4 * 1024 * 1024)
+        file.seek(_SPARSE_HOLE_BYTES)
         assert file.read(3) == b"end"
     assert target.stat().st_blocks * 512 < target.stat().st_size
 
@@ -198,7 +207,7 @@ def test_native_clone_or_sparse_copy_preserves_sparse_holes(tmp_path: Path) -> N
 def test_native_decompress_zstd_sparse_preserves_sparse_holes(tmp_path: Path) -> None:
     """Native zstd decompression should avoid allocating zero-filled ranges."""
     zstandard = pytest.importorskip("zstandard")
-    plain = b"start" + (b"\0" * (4 * 1024 * 1024)) + b"end"
+    plain = b"start" + (b"\0" * _SPARSE_HOLE_BYTES) + b"end"
     source = tmp_path / "rootfs.ext4.zst"
     target = tmp_path / "rootfs.ext4"
     source.write_bytes(zstandard.ZstdCompressor(level=3).compress(plain))

--- a/tests/test_smolvm_core.py
+++ b/tests/test_smolvm_core.py
@@ -166,32 +166,28 @@ def test_production_code_does_not_import_private_core_extension() -> None:
     assert offenders == []
 
 
-# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
-# map is irrelevant; what decides whether the TARGET ends up sparse is its size
-# on the volume the test runs on. On one macOS volume a written extent below
-# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
-# volumes on the same machine punch holes from 1 MiB. The mechanism is not
-# identified, so treat this as a margin rather than a bound.
-_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
-
-
-def _write_sparse_file(path: Path) -> None:
+def _write_sparse_file(path: Path, hole_bytes: int) -> None:
     with path.open("wb") as file:
         file.write(b"start")
-        file.seek(_SPARSE_HOLE_BYTES)
+        file.seek(hole_bytes)
         file.write(b"end")
 
 
-def _assert_sparse_image(path: Path, expected: bytes) -> None:
+def _assert_sparse_image(path: Path, expected: bytes, *, assert_sparse: bool) -> None:
     assert path.read_bytes() == expected
-    assert path.stat().st_blocks * 512 < path.stat().st_size
+    if assert_sparse:
+        assert path.stat().st_blocks * 512 < path.stat().st_size
 
 
-def test_native_clone_or_sparse_copy_preserves_sparse_holes(tmp_path: Path) -> None:
+def test_native_clone_or_sparse_copy_preserves_sparse_holes(
+    tmp_path: Path,
+    sparse_test_config: tuple[int, bool],
+) -> None:
     """Native disk copy should keep sparse raw-rootfs holes sparse."""
+    hole_bytes, supports_sparse_allocation = sparse_test_config
     source = tmp_path / "source.ext4"
     target = tmp_path / "target.ext4"
-    _write_sparse_file(source)
+    _write_sparse_file(source, hole_bytes)
 
     method = smolvm_core.disk.clone_or_sparse_copy(str(source), str(target))
 
@@ -199,15 +195,20 @@ def test_native_clone_or_sparse_copy_preserves_sparse_holes(tmp_path: Path) -> N
     assert target.stat().st_size == source.stat().st_size
     with target.open("rb") as file:
         assert file.read(5) == b"start"
-        file.seek(_SPARSE_HOLE_BYTES)
+        file.seek(hole_bytes)
         assert file.read(3) == b"end"
-    assert target.stat().st_blocks * 512 < target.stat().st_size
+    if supports_sparse_allocation:
+        assert target.stat().st_blocks * 512 < target.stat().st_size
 
 
-def test_native_decompress_zstd_sparse_preserves_sparse_holes(tmp_path: Path) -> None:
+def test_native_decompress_zstd_sparse_preserves_sparse_holes(
+    tmp_path: Path,
+    sparse_test_config: tuple[int, bool],
+) -> None:
     """Native zstd decompression should avoid allocating zero-filled ranges."""
     zstandard = pytest.importorskip("zstandard")
-    plain = b"start" + (b"\0" * _SPARSE_HOLE_BYTES) + b"end"
+    hole_bytes, supports_sparse_allocation = sparse_test_config
+    plain = b"start" + (b"\0" * hole_bytes) + b"end"
     source = tmp_path / "rootfs.ext4.zst"
     target = tmp_path / "rootfs.ext4"
     source.write_bytes(zstandard.ZstdCompressor(level=3).compress(plain))
@@ -215,7 +216,7 @@ def test_native_decompress_zstd_sparse_preserves_sparse_holes(tmp_path: Path) ->
     method = smolvm_core.disk.decompress_zstd_sparse(str(source), str(target), 1024 * 1024)
 
     assert method == "sparse"
-    _assert_sparse_image(target, plain)
+    _assert_sparse_image(target, plain, assert_sparse=supports_sparse_allocation)
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific unsupported helper path")

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -607,6 +607,15 @@ class TestSmolVMCreate:
         mock_network.async_setup_ssh_port_forward.assert_not_called()
 
 
+# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
+# map is irrelevant; what decides whether the TARGET ends up sparse is its size
+# on the volume the test runs on. On one macOS volume a written extent below
+# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
+# volumes on the same machine punch holes from 1 MiB. The mechanism is not
+# identified, so treat this as a margin rather than a bound.
+_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
+
+
 class TestSmolVMDiskLifecycle:
     """Tests for per-VM disk materialization and cleanup."""
 
@@ -614,7 +623,7 @@ class TestSmolVMDiskLifecycle:
     def _write_sparse_file(path: Path) -> None:
         with path.open("wb") as file:
             file.write(b"start")
-            file.seek(4 * 1024 * 1024)
+            file.seek(_SPARSE_HOLE_BYTES)
             file.write(b"end")
 
     @staticmethod
@@ -622,7 +631,7 @@ class TestSmolVMDiskLifecycle:
         assert target.stat().st_size == source.stat().st_size
         with target.open("rb") as file:
             assert file.read(5) == b"start"
-            file.seek(4 * 1024 * 1024)
+            file.seek(_SPARSE_HOLE_BYTES)
             assert file.read(3) == b"end"
         assert target.stat().st_blocks * 512 < target.stat().st_size
 

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -607,33 +607,31 @@ class TestSmolVMCreate:
         mock_network.async_setup_ssh_port_forward.assert_not_called()
 
 
-# 32 MiB. `sparse_copy` decides per chunk by content, so the source's own hole
-# map is irrelevant; what decides whether the TARGET ends up sparse is its size
-# on the volume the test runs on. On one macOS volume a written extent below
-# ~16 MiB comes back fully allocated while 32 MiB does not, and other APFS
-# volumes on the same machine punch holes from 1 MiB. The mechanism is not
-# identified, so treat this as a margin rather than a bound.
-_SPARSE_HOLE_BYTES = 32 * 1024 * 1024
-
-
 class TestSmolVMDiskLifecycle:
     """Tests for per-VM disk materialization and cleanup."""
 
     @staticmethod
-    def _write_sparse_file(path: Path) -> None:
+    def _write_sparse_file(path: Path, hole_bytes: int) -> None:
         with path.open("wb") as file:
             file.write(b"start")
-            file.seek(_SPARSE_HOLE_BYTES)
+            file.seek(hole_bytes)
             file.write(b"end")
 
     @staticmethod
-    def _assert_sparse_copy(source: Path, target: Path) -> None:
+    def _assert_sparse_copy(
+        source: Path,
+        target: Path,
+        *,
+        hole_bytes: int,
+        assert_sparse: bool,
+    ) -> None:
         assert target.stat().st_size == source.stat().st_size
         with target.open("rb") as file:
             assert file.read(5) == b"start"
-            file.seek(_SPARSE_HOLE_BYTES)
+            file.seek(hole_bytes)
             assert file.read(3) == b"end"
-        assert target.stat().st_blocks * 512 < target.stat().st_size
+        if assert_sparse:
+            assert target.stat().st_blocks * 512 < target.stat().st_size
 
     def test_copy_with_reflink_uses_host_disk_helper(self, tmp_path: Path) -> None:
         """Raw isolated-disk copies should go through the host disk switchboard."""
@@ -650,11 +648,13 @@ class TestSmolVMDiskLifecycle:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
+        sparse_test_config: tuple[int, bool],
     ) -> None:
         """The non-GNU cp fallback should also avoid writing sparse zero ranges."""
+        hole_bytes, supports_sparse_allocation = sparse_test_config
         source = tmp_path / "source.ext4"
         target = tmp_path / "target.ext4"
-        self._write_sparse_file(source)
+        self._write_sparse_file(source, hole_bytes)
         monkeypatch.setenv("SMOLVM_DISABLE_NATIVE_DISK", "1")
 
         with (
@@ -670,18 +670,25 @@ class TestSmolVMDiskLifecycle:
             mock_core_disk.clone_or_sparse_copy.side_effect = AssertionError("core disabled")
             SmolVMManager._copy_with_reflink(source, target)
 
-        self._assert_sparse_copy(source, target)
+        self._assert_sparse_copy(
+            source,
+            target,
+            hole_bytes=hole_bytes,
+            assert_sparse=supports_sparse_allocation,
+        )
 
     @pytest.mark.asyncio
     async def test_async_copy_with_reflink_fallback_preserves_sparse_holes(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
+        sparse_test_config: tuple[int, bool],
     ) -> None:
         """Async disk materialization should use the same sparse fallback."""
+        hole_bytes, supports_sparse_allocation = sparse_test_config
         source = tmp_path / "source.ext4"
         target = tmp_path / "target.ext4"
-        self._write_sparse_file(source)
+        self._write_sparse_file(source, hole_bytes)
         manager = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets")
         monkeypatch.setenv("SMOLVM_DISABLE_NATIVE_DISK", "1")
 
@@ -698,7 +705,12 @@ class TestSmolVMDiskLifecycle:
             mock_core_disk.clone_or_sparse_copy.side_effect = AssertionError("core disabled")
             await manager._async_copy_with_reflink(source, target)
 
-        self._assert_sparse_copy(source, target)
+        self._assert_sparse_copy(
+            source,
+            target,
+            hole_bytes=hole_bytes,
+            assert_sparse=supports_sparse_allocation,
+        )
 
     @patch("smolvm.vm.NetworkManager")
     def test_create_materializes_isolated_disk(


### PR DESCRIPTION
`pyproject.toml` lists `Operating System :: MacOS :: MacOS X` first and `CONTRIBUTING.md:53`
documents macOS with the QEMU backend, but `pytest.yml` only ran `ubuntu-latest`. On a clean checkout
of `main` at `b617ca0`: **11 failed, 2005 passed, 26 skipped**. After this branch: **2016 passed, 26
skipped, 0 failed** — the skip *set* is byte-identical, so all 11 genuinely run and pass.

**Tests and CI only. `src/` is untouched.**

## 1 · Four completion tests read the host's platform instead of pinning it

`_rc_path` deliberately returns `.bash_profile` on Darwin (`completion.py:103-111`, with a comment
about login shells). Four tests assert `.bashrc` literally, so on macOS they read a file that was
never written — the failing run's own stdout says `added one line to '…/.bash_profile'`.

Fixed with the idiom already in the same class: `test_cli.py:5514` pins `platform.system` to
`"Darwin"` for the macOS branch. The four generic tests take the mirror pin, `"Linux"`, and keep
`.bashrc` as a literal.

⚠ **Mutation-checked, because the obvious fix is a trap.** Making the tests ask `_rc_path` for the
expected filename makes them compute their expectation with the function under test: under that
version, forcing `_rc_path` to return `.MUTANT_rc` failed **0** tests, on Linux too. Under what is
proposed here it fails **4**.

## 2 · Six sparse assertion sites use fixtures too small to observe a hole *on some volumes*

⚠ **The mechanism is not what it looks like, and the first draft of this PR got it wrong.**
`sparse_copy` (`smolvm-core/src/disk.rs:124`, `host/disk.py:168`) decides **per chunk, by content** —
it never reads the source's hole map. So whether the *fixture* contains a hole is irrelevant. What
decides the outcome is **the size of the target file on the volume the test runs on**:

```
source dense-written 32 MiB, no hole at all  -> clone_or_sparse_copy -> TARGET sparse
source with a real 4 MiB hole                -> clone_or_sparse_copy -> TARGET fully allocated
```

⚠ **And "~16 MiB on APFS" is a property of one volume, not of APFS.** Same machine, same kernel:

| volume | sparse from |
|---|---|
| System Data volume (where `$TMPDIR` and the repo live) | **~16 MiB** |
| APFS sparse images (512 MB, 300 GB), encrypted, case-sensitive | **1 MiB** |
| HFS+ | **never, not even at 64 MiB** |

Volume size, `f_bsize`, encryption, case-sensitivity and free space were each ruled out. **The
mechanism is unidentified**, so 32 MiB is a margin over one observation, not a bound — the comments
in the touched files say exactly that rather than asserting a filesystem property.

⛔ **Known regression, disclosed rather than hidden: on a volume that never punches holes (HFS+),
this makes things worse.** Same five files, `TMPDIR` on HFS+: base **8 failed, 138 MiB** scratch;
this branch **10 failed, ~492 MiB**, filling the volume — the two extra failures are an ENOSPC
cascade, not a sparseness failure. Anyone developing on an HFS+ volume is worse off. If that matters
to you, say so and the sparse half comes out; §1 is independent.

⚠ **Cost:** peak RSS on the five touched files 125 → 201 MiB (+61%); those files 2.55s → 3.16s; full
suite +1%. `test_image_transfer.py` holds a 32 MiB module-level `bytes` for the session.

★ The principle is already in your own file: `test_image_cmd.py:144 test_total_size_is_sparse_aware`
builds a **64 MiB** image, comments *"64 MiB apparent, ~0 allocated"*, and is the one sparse
assertion that passes on macOS today.

## 3 · One macOS leg in CI

`include:` adds a single `macos-latest` job. **Your existing check names are untouched** — `label` is
undefined on the ubuntu legs so it renders empty, leaving `pytest (Python 3.13)` and
`pytest (Python 3.14)` exactly as they are, which matters because `merge_group` gates on names. The
new job is `pytest (Python 3.14, macOS)`.

`HAS_NETLINK` is Linux-only and `False` on macOS by design, so that step is gated to Linux and macOS
asserts `disk.available()`. ⚠ An earlier draft asserted `hasattr(disk, 'clone_or_sparse_copy')`,
which is a plain `def` in the pure-Python shim and therefore **can never fail**; `disk.available()`
actually enters the extension.

## Verification, and what is still a bet

macOS 15 (Darwin 25.6.0, arm64, APFS), Python 3.14.3: **2016 passed, 26 skipped, 0 failed**.
`ruff check .` and `ruff format --check .` clean across 259 files. Four mutants — `_write_sparse_chunk`
always-write, `smolvm_core.disk` dense-copy-but-report-sparse, `_size_on_disk` returning `st_size`,
and `_rc_path` — are each caught by 2-4 of the touched tests, so none of the 11 became a no-op.

✅ **The macOS CI job has now been run on a GitHub-hosted runner** (`zorionarrillaga/SmolVM`, run
33006904959, commit `69ac017`): `pytest (Python 3.14, macOS)` → **2016 passed, 26 skipped, 30
deselected**, identical to the local macOS figures. `Lint` and `package-smoke` green on the same
commit. All eleven formerly-failing tests were confirmed **PASSED by name**, not inferred from a
count, and **none of them skipped** — which was the failure mode worth fearing:

```
test_completion_install_bash_writes_script_and_rc_line   PASSED
test_completion_install_is_idempotent                    PASSED
test_completion_install_quotes_path_with_apostrophe      PASSED
test_completion_install_under_sudo_targets_real_user_home PASSED
test_inspect_exact_name_returns_array                    PASSED
test_published_entry_round_trips                         PASSED
test_decompress_zstd_preserves_sparse_zero_ranges        PASSED
test_native_clone_or_sparse_copy_preserves_sparse_holes  PASSED
test_native_decompress_zstd_sparse_preserves_sparse_holes PASSED
test_copy_with_reflink_fallback_preserves_sparse_holes   PASSED
test_async_copy_with_reflink_fallback_preserves_sparse_holes PASSED
```

⚠ That is one more data point, not a proof about macOS generally: a GitHub `macos-latest` runner
volume behaves like the author's. The HFS+ regression above is unchanged and still disclosed.
✅ **The Linux legs are now EXECUTED, not reasoned.** The test half of this branch was run through
GitHub Actions on `ubuntu-latest`, Python 3.13 and 3.14, and compared against your own CI run at
`b617ca0`:

| | passed | skipped | deselected |
|---|---|---|---|
| your CI at `b617ca0` (run 32665263011) | 2022 | 20 | 30 |
| this branch, same runner image | **2022** | **20** | **30** |

Identical. **No sparse test skipped on Linux** — the six run against ext4 with the larger fixtures and
pass, so the change costs no coverage there. `Lint` and `package-smoke` green on the same commit.
⚠ The local run used the **released `smolvm-core` PyPI wheel** (`INSTALLER: pip`, maturin tag
`cp314-…-macosx_11_0_arm64`), not a cargo build of `smolvm-core/src/disk.rs` at `b617ca0`. CI builds
from the tree.
⚠ Citations resolve against `b617ca0`; six of nine point elsewhere on the branch head, which is what
"Files changed" renders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform coverage across Linux and macOS environments.
  * Made shell completion tests consistent regardless of the host operating system.
  * Enhanced sparse-file tests to adapt to filesystem capabilities while validating data integrity, copying, decompression, and published image handling.
  * Added platform-aware checks for native networking and disk I/O capabilities.

* **Chores**
  * Updated automated testing workflows to include macOS with Python 3.14 while preserving existing Linux checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->