### PR TITLE
feat: add preset-aware OpenClaw sandbox listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ OpenClaw also has a private browser dashboard. Open it after the named sandbox s
 
 ```bash
 smolvm openclaw list
-# NAME              PRESET     STATUS   PID
-# openclaw-work     openclaw   running  12345
+# NAME              STATUS   PID
+# openclaw-work     running  12345
 
 smolvm openclaw open openclaw-work
 ```

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ smolvm openclaw start --name openclaw-work --no-attach
 OpenClaw also has a private browser dashboard. Open it after the named sandbox starts:
 
 ```bash
+smolvm openclaw list
+# NAME              STATUS   PID
+# openclaw-work     running  12345
+
 smolvm openclaw open openclaw-work
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ smolvm sandbox create --name my-sandbox
 # my-sandbox  running  172.16.0.2
 
 smolvm sandbox list
-# NAME         STATUS   IP
-# my-sandbox   running  172.16.0.2
+# NAME         PRESET  STATUS   PID
+# my-sandbox   -       running  12345
 
 smolvm sandbox stop my-sandbox
 ```
@@ -231,8 +231,8 @@ OpenClaw also has a private browser dashboard. Open it after the named sandbox s
 
 ```bash
 smolvm openclaw list
-# NAME              STATUS   PID
-# openclaw-work     running  12345
+# NAME              PRESET     STATUS   PID
+# openclaw-work     openclaw   running  12345
 
 smolvm openclaw open openclaw-work
 ```

--- a/docs/guides/agent-presets.md
+++ b/docs/guides/agent-presets.md
@@ -32,6 +32,16 @@ For this release, creating a new OpenClaw sandbox can take several minutes becau
 smolvm openclaw start --name openclaw-work --no-attach
 ```
 
+List running sandboxes when you need to find its name:
+
+```bash
+smolvm openclaw list
+# NAME              STATUS   PID
+# openclaw-work     running  12345
+```
+
+The list includes every sandbox because older and custom-named sandboxes do not record which preset created them. Add `--all` to include stopped sandboxes, or `--status STATUS` to choose one state.
+
 Then open its private dashboard through a localhost-only connection:
 
 ```bash

--- a/docs/guides/agent-presets.md
+++ b/docs/guides/agent-presets.md
@@ -36,8 +36,8 @@ List running sandboxes when you need to find its name:
 
 ```bash
 smolvm openclaw list
-# NAME              PRESET     STATUS   PID
-# openclaw-work     openclaw   running  12345
+# NAME              STATUS   PID
+# openclaw-work     running  12345
 ```
 
 This command shows running sandboxes created by the OpenClaw preset. Add `--all` to include stopped OpenClaw sandboxes, or `--status STATUS` to choose one state.

--- a/docs/guides/agent-presets.md
+++ b/docs/guides/agent-presets.md
@@ -36,11 +36,21 @@ List running sandboxes when you need to find its name:
 
 ```bash
 smolvm openclaw list
-# NAME              STATUS   PID
-# openclaw-work     running  12345
+# NAME              PRESET     STATUS   PID
+# openclaw-work     openclaw   running  12345
 ```
 
-The list includes every sandbox because older and custom-named sandboxes do not record which preset created them. Add `--all` to include stopped sandboxes, or `--status STATUS` to choose one state.
+This command shows running sandboxes created by the OpenClaw preset. Add `--all` to include stopped OpenClaw sandboxes, or `--status STATUS` to choose one state.
+
+Use the generic preset filter when you are working with the full sandbox inventory:
+
+```bash
+smolvm sandbox list --preset openclaw
+# NAME              PRESET     STATUS   PID
+# openclaw-work     openclaw   running  12345
+```
+
+Sandboxes created before preset tracking do not appear in either filtered list. They remain available through `smolvm sandbox list --all`, where the Preset column shows `-`.
 
 Then open its private dashboard through a localhost-only connection:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,7 +48,7 @@ Run these in the order you need them:
 
 ## Start a prepared agent
 
-`smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` create a sandbox and install that agent. `smolvm openclaw open SANDBOX` starts or reuses its gateway and opens the dashboard over a localhost-only connection. Add `--host-port PORT` to choose the local port, `--no-browser` to print the one-time link, or `--json` for structured output. The current OpenClaw fallback installation can take several minutes; see [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
+`smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` create a sandbox and install that agent. Run `smolvm openclaw list` to find a sandbox, then `smolvm openclaw open SANDBOX` to start or reuse its gateway and open the dashboard over a localhost-only connection. Add `--all` or `--status STATUS` to filter the list. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output. The current OpenClaw fallback installation can take several minutes; see [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
 
 ## Manage downloaded images
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,7 +27,7 @@ Run these in the order you need them:
 | Command | Use it to |
 | --- | --- |
 | `smolvm sandbox create` | Create a sandbox. Add `--network bridge --bridge BRIDGE` only when the sandbox should appear as a separate computer on that network. |
-| `smolvm sandbox list` / `info` | Find or inspect sandboxes. |
+| `smolvm sandbox list` / `info` | Find or inspect sandboxes. Add `--preset PRESET` to list sandboxes created by one agent preset. |
 | `smolvm sandbox shell` / `ssh` | Open a shell. `shell` uses SmolVM's fast control channel when available; `ssh` explicitly uses SSH. |
 | `smolvm sandbox desktop` | Open a running macOS sandbox in Screen Sharing. Add `--start` to start it first. |
 | `smolvm sandbox exec` | Run one command inside a running sandbox and print its output — handy for scripts and agents. Put the command after `--`, e.g. `smolvm sandbox exec my-sandbox -- ls -la`. Add `--start` to start the sandbox first if it isn't running. |
@@ -48,7 +48,7 @@ Run these in the order you need them:
 
 ## Start a prepared agent
 
-`smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` create a sandbox and install that agent. Run `smolvm openclaw list` to find a sandbox, then `smolvm openclaw open SANDBOX` to start or reuse its gateway and open the dashboard over a localhost-only connection. Add `--all` or `--status STATUS` to filter the list. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output. The current OpenClaw fallback installation can take several minutes; see [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
+`smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` create a sandbox and install that agent. Run `smolvm openclaw list` to find an OpenClaw sandbox; `smolvm sandbox list --preset openclaw` is the generic equivalent. Add `--all` to include stopped sandboxes or `--status STATUS` to choose one state. Then run `smolvm openclaw open SANDBOX` to start or reuse its gateway and open the dashboard over a localhost-only connection. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output. Sandboxes created before preset tracking remain visible in unfiltered sandbox listings but are excluded from preset-filtered results. The current OpenClaw fallback installation can take several minutes; see [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
 
 ## Manage downloaded images
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,7 +48,13 @@ Run these in the order you need them:
 
 ## Start a prepared agent
 
-`smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` create a sandbox and install that agent. Run `smolvm openclaw list` to find an OpenClaw sandbox; `smolvm sandbox list --preset openclaw` is the generic equivalent. Add `--all` to include stopped sandboxes or `--status STATUS` to choose one state. Then run `smolvm openclaw open SANDBOX` to start or reuse its gateway and open the dashboard over a localhost-only connection. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output. Sandboxes created before preset tracking remain visible in unfiltered sandbox listings but are excluded from preset-filtered results. The current OpenClaw fallback installation can take several minutes; see [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
+`smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` each create a sandbox and install that agent.
+
+- Create and install OpenClaw with `smolvm openclaw start`.
+- Find an OpenClaw sandbox with `smolvm openclaw list`, or use the generic `smolvm sandbox list --preset openclaw`. Add `--all` to include stopped sandboxes or `--status STATUS` to choose one state.
+- Open the dashboard with `smolvm openclaw open SANDBOX`. It starts or reuses the gateway and connects it over localhost only. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output.
+- Sandboxes created before preset tracking remain visible in unfiltered sandbox listings but are excluded from preset-filtered results.
+- The current OpenClaw fallback installation can take several minutes. See [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
 
 ## Manage downloaded images
 

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -26,6 +26,7 @@ from smolvm.cli.commands.options import (
 )
 from smolvm.cli.version_check import maybe_print_update_notice
 from smolvm.host.doctor import run_doctor
+from smolvm.presets import canonical_preset_name, public_preset_name, public_preset_names
 from smolvm.types import BrowserSessionState, GuestFlushPolicy, GuestOS, SnapshotType, VMState
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -184,8 +185,20 @@ def sandbox_create(
     type=click.Choice([state.value for state in VMState]),
     default=None,
 )
+@click.option(
+    "--preset",
+    "preset_filter",
+    type=click.Choice(public_preset_names()),
+    default=None,
+    help="Show sandboxes created by this preset.",
+)
 @json_option
-def sandbox_list(include_all: bool, status_filter: str | None, json_output: bool) -> Any:
+def sandbox_list(
+    include_all: bool,
+    status_filter: str | None,
+    preset_filter: str | None,
+    json_output: bool,
+) -> Any:
     """List your sandboxes."""
     if include_all and status_filter is not None:
         raise click.UsageError(
@@ -196,6 +209,7 @@ def sandbox_list(include_all: bool, status_filter: str | None, json_output: bool
     return _handlers()._run_list(
         include_all=include_all,
         status_filter=status_filter,
+        preset_filter=canonical_preset_name(preset_filter) if preset_filter else None,
         json_output=json_output,
         command_name="sandbox.list",
     )
@@ -1467,9 +1481,7 @@ def _register_preset_commands() -> None:
     from smolvm.presets import list_presets
 
     for preset in list_presets():
-        public_name = "claude" if preset.name == "claude-code" else preset.name
-        if public_name not in {"codex", "claude", "openclaw", "opencode", "hermes", "pi"}:
-            continue
+        public_name = public_preset_name(preset.name)
 
         @click.group(public_name, context_settings=CONTEXT_SETTINGS, help=preset.summary)
         def preset_group() -> None:
@@ -1591,7 +1603,7 @@ def _register_preset_commands() -> None:
         )
         if preset.name == "openclaw":
 
-            @click.command("list", help="List sandboxes so you can choose one for OpenClaw.")
+            @click.command("list", help="List sandboxes created by the OpenClaw preset.")
             @click.option("--all", "include_all", is_flag=True, help="Show all sandboxes.")
             @click.option(
                 "--status",
@@ -1605,7 +1617,7 @@ def _register_preset_commands() -> None:
                 status_filter: str | None,
                 json_output: bool,
             ) -> Any:
-                """List sandboxes so you can choose one for OpenClaw."""
+                """List sandboxes created by the OpenClaw preset."""
                 if include_all and status_filter is not None:
                     raise click.UsageError(
                         "Use one filter. Run 'smolvm openclaw list --all' or "
@@ -1615,6 +1627,7 @@ def _register_preset_commands() -> None:
                 return _handlers()._run_list(
                     include_all=include_all,
                     status_filter=status_filter,
+                    preset_filter="openclaw",
                     json_output=json_output,
                     command_name="openclaw.list",
                 )

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -1628,6 +1628,7 @@ def _register_preset_commands() -> None:
                     include_all=include_all,
                     status_filter=status_filter,
                     preset_filter="openclaw",
+                    show_preset_column=False,
                     json_output=json_output,
                     command_name="openclaw.list",
                 )

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -1591,6 +1591,34 @@ def _register_preset_commands() -> None:
         )
         if preset.name == "openclaw":
 
+            @click.command("list", help="List sandboxes so you can choose one for OpenClaw.")
+            @click.option("--all", "include_all", is_flag=True, help="Show all sandboxes.")
+            @click.option(
+                "--status",
+                "status_filter",
+                type=click.Choice([state.value for state in VMState]),
+                default=None,
+            )
+            @json_option
+            def openclaw_list(
+                include_all: bool,
+                status_filter: str | None,
+                json_output: bool,
+            ) -> Any:
+                """List sandboxes so you can choose one for OpenClaw."""
+                if include_all and status_filter is not None:
+                    raise click.UsageError(
+                        "Use one filter. Run 'smolvm openclaw list --all' or "
+                        "'smolvm openclaw list --status running'."
+                    )
+                _before_command(json_output=json_output)
+                return _handlers()._run_list(
+                    include_all=include_all,
+                    status_filter=status_filter,
+                    json_output=json_output,
+                    command_name="openclaw.list",
+                )
+
             @click.command("open", help="Open this sandbox's OpenClaw dashboard.")
             @click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
             @click.option(
@@ -1630,6 +1658,7 @@ def _register_preset_commands() -> None:
                     )
                 )
 
+            preset_group.add_command(openclaw_list)
             preset_group.add_command(openclaw_open)
         cli.add_command(preset_group)
 

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -90,12 +90,9 @@ def _canonical_preset(name: str) -> str:
     Alias data lives on the preset definitions themselves so a new alias
     automatically works here without touching this module.
     """
-    from smolvm.presets import list_presets
+    from smolvm.presets import canonical_preset_name
 
-    for preset in list_presets():
-        if name == preset.name or name in preset.aliases:
-            return preset.name
-    return name
+    return canonical_preset_name(name)
 
 
 def _created_iso(path: Path) -> str | None:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -453,25 +453,32 @@ def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
     return rows
 
 
-def _render_list(rows: list[VmRow]) -> None:
+def _render_list(rows: list[VmRow], *, show_preset_column: bool = True) -> None:
     """Render the human-facing VM list."""
     from smolvm.presets import public_preset_name
 
     table = Table(title="SmolVM Instances")
     table.add_column("Name")
-    table.add_column("Preset")
+    if show_preset_column:
+        table.add_column("Preset")
     table.add_column("Status")
     table.add_column("PID", justify="right")
     for row in rows:
         name = str(row["name"])
         if row["warnings"]:
             name = f"⚠ {name}"
-        table.add_row(
+        values: list[str | Text] = [
             name,
-            public_preset_name(row["preset"]) if row["preset"] else "-",
-            Text(str(row["status"]), style=status_style(str(row["status"]))),
-            str(row["pid"] or "-"),
+        ]
+        if show_preset_column:
+            values.append(public_preset_name(row["preset"]) if row["preset"] else "-")
+        values.extend(
+            [
+                Text(str(row["status"]), style=status_style(str(row["status"]))),
+                str(row["pid"] or "-"),
+            ]
         )
+        table.add_row(*values)
 
     console = console_stdout()
     console.print(table)
@@ -613,6 +620,7 @@ def _run_list(
     include_all: bool,
     status_filter: str | None,
     preset_filter: str | None = None,
+    show_preset_column: bool = True,
     json_output: bool,
     command_name: str = "sandbox.list",
 ) -> int:
@@ -666,7 +674,7 @@ def _run_list(
                 render_empty("SmolVM Instances", message)
                 return 0
 
-            _render_list(rows)
+            _render_list(rows, show_preset_column=show_preset_column)
             return 0
         except Exception as exc:
             return _emit_cli_error(command_name, 1, exc, json_output=json_output)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -3544,7 +3544,7 @@ def _run_openclaw_open(args: SimpleNamespace) -> int:
     except Exception as exc:
         if isinstance(exc, VMNotFoundError):
             exc = RuntimeError(
-                f"Sandbox '{args.vm_id}' was not found; run 'smolvm sandbox list --all' "
+                f"Sandbox '{args.vm_id}' was not found; run 'smolvm openclaw list --all' "
                 f"to choose one, or 'smolvm openclaw start --name {args.vm_id} "
                 "--no-attach' to create it."
             )

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -103,6 +103,7 @@ class VmRow(TypedDict):
     """Machine-readable data for a listed VM."""
 
     name: str
+    preset: str | None
     status: str
     pid: int | None
     ip_address: str | None
@@ -115,6 +116,7 @@ class ListFiltersPayload(TypedDict):
 
     all: bool
     status: str | None
+    preset: str | None
 
 
 class ListPayload(TypedDict):
@@ -440,6 +442,7 @@ def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
         rows.append(
             {
                 "name": vm.vm_id,
+                "preset": vm.config.preset,
                 "status": vm.status.value,
                 "pid": vm.pid,
                 "ip_address": ip_address,
@@ -452,8 +455,11 @@ def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
 
 def _render_list(rows: list[VmRow]) -> None:
     """Render the human-facing VM list."""
+    from smolvm.presets import public_preset_name
+
     table = Table(title="SmolVM Instances")
     table.add_column("Name")
+    table.add_column("Preset")
     table.add_column("Status")
     table.add_column("PID", justify="right")
     for row in rows:
@@ -462,6 +468,7 @@ def _render_list(rows: list[VmRow]) -> None:
             name = f"⚠ {name}"
         table.add_row(
             name,
+            public_preset_name(row["preset"]) if row["preset"] else "-",
             Text(str(row["status"]), style=status_style(str(row["status"]))),
             str(row["pid"] or "-"),
         )
@@ -605,6 +612,7 @@ def _run_list(
     *,
     include_all: bool,
     status_filter: str | None,
+    preset_filter: str | None = None,
     json_output: bool,
     command_name: str = "sandbox.list",
 ) -> int:
@@ -614,7 +622,10 @@ def _run_list(
         try:
             effective_status = status_filter or (None if include_all else VMState.RUNNING.value)
             state = VMState(effective_status) if effective_status else None
-            vms = sdk.list_vms(status=state)
+            query_state = None if state is VMState.ERROR else state
+            vms = sdk.list_vms(status=query_state)
+            if preset_filter is not None:
+                vms = [vm for vm in vms if vm.config.preset == preset_filter]
             # Cheap per-row liveness check: a VM marked RUNNING/PAUSED whose
             # QEMU process is gone gets demoted to ERROR right here, so the
             # rendered table reflects reality instead of a stale DB row.
@@ -626,6 +637,7 @@ def _run_list(
                 "filters": {
                     "all": include_all,
                     "status": effective_status,
+                    "preset": preset_filter,
                 },
                 "vms": rows,
             }
@@ -634,7 +646,18 @@ def _run_list(
                 return 0
 
             if not vms:
-                if status_filter:
+                if preset_filter is not None:
+                    from smolvm.presets import public_preset_name
+
+                    public_name = public_preset_name(preset_filter)
+                    if status_filter:
+                        message = f"No '{public_name}' sandboxes with status '{status_filter}'."
+                    elif include_all:
+                        message = f"No '{public_name}' sandboxes found."
+                    else:
+                        message = f"No running '{public_name}' sandboxes found."
+                    message += f" Run 'smolvm {public_name} start'."
+                elif status_filter:
                     message = f"No VMs found with status '{status_filter}'."
                 elif include_all:
                     message = "No VMs found."
@@ -1600,6 +1623,7 @@ def _run_start_with_published_image(args: SimpleNamespace, preset: object) -> in
 
         config = VMConfig(
             vm_id=_resolve_vm_name(args.name, prefix=_preset.name),
+            preset=_preset.name,
             memory=args.memory_mib if args.memory_mib is not None else _preset.default_mem_mib,
             kernel_path=local_image.kernel_path,
             rootfs_path=local_image.rootfs_path,
@@ -1775,6 +1799,7 @@ def _run_start(args: SimpleNamespace) -> int:
                 build_fn=lambda on_download: _build_auto_config(
                     vm_name=args.name,
                     name_prefix=preset.name,
+                    preset_name=preset.name,
                     os=requested_os,
                     backend=backend,
                     qemu_machine=args.qemu_machine,
@@ -1802,6 +1827,7 @@ def _run_start(args: SimpleNamespace) -> int:
             config, ssh_key_path = _build_auto_config(
                 vm_name=args.name,
                 name_prefix=preset.name,
+                preset_name=preset.name,
                 os=requested_os,
                 backend=backend,
                 qemu_machine=args.qemu_machine,
@@ -3544,7 +3570,7 @@ def _run_openclaw_open(args: SimpleNamespace) -> int:
     except Exception as exc:
         if isinstance(exc, VMNotFoundError):
             exc = RuntimeError(
-                f"Sandbox '{args.vm_id}' was not found; run 'smolvm openclaw list --all' "
+                f"Sandbox '{args.vm_id}' was not found; run 'smolvm sandbox list --all' "
                 f"to choose one, or 'smolvm openclaw start --name {args.vm_id} "
                 "--no-attach' to create it."
             )

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -557,6 +557,7 @@ def _build_auto_config(
     *,
     vm_name: str | None = None,
     name_prefix: str = "sbx",
+    preset_name: str | None = None,
     os: GuestOS | str | None = None,
     backend: str | None = None,
     qemu_machine: QemuMachine = "auto",
@@ -607,6 +608,7 @@ def _build_auto_config(
         )
         config = VMConfig(
             vm_id=resolved_vm_name,
+            preset=preset_name,
             vcpu_count=manifest.cpu_count,
             memory=manifest.memory_mib,
             guest_os=GuestOS.MACOS,
@@ -675,6 +677,7 @@ def _build_auto_config(
         )
         config = VMConfig(
             vm_id=resolved_vm_name,
+            preset=preset_name,
             vcpu_count=1,
             memory=resolved_memory,
             kernel_path=local_image.kernel_path,
@@ -728,6 +731,7 @@ def _build_auto_config(
     resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
     config = VMConfig(
         vm_id=resolved_vm_name,
+        preset=preset_name,
         vcpu_count=1,
         memory=resolved_memory,
         kernel_path=kernel,

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -47,6 +47,9 @@ _BUILTIN_PRESETS: tuple[Preset, ...] = (
 )
 
 _REGISTRY: dict[str, Preset] = {p.name: p for p in _BUILTIN_PRESETS}
+_PUBLIC_NAMES: dict[str, str] = {
+    "claude-code": "claude",
+}
 
 
 def list_presets() -> list[Preset]:
@@ -67,6 +70,24 @@ def get_preset(name: str) -> Preset:
     except KeyError as exc:
         available = ", ".join(sorted(_REGISTRY))
         raise KeyError(f"Unknown preset {name!r}. Available: {available}") from exc
+
+
+def canonical_preset_name(name: str) -> str:
+    """Return the canonical preset name for a CLI-facing name or alias."""
+    for preset in _REGISTRY.values():
+        if name == preset.name or name in preset.aliases:
+            return preset.name
+    return name
+
+
+def public_preset_name(name: str) -> str:
+    """Return the user-facing CLI name for a canonical preset name."""
+    return _PUBLIC_NAMES.get(name, name)
+
+
+def public_preset_names() -> list[str]:
+    """Return preset names exposed by top-level CLI command groups."""
+    return sorted(public_preset_name(name) for name in _REGISTRY)
 
 
 def preset_names() -> list[str]:
@@ -99,6 +120,7 @@ __all__ = [
     "HostKeychainSecret",
     "Preset",
     "apply_preset",
+    "canonical_preset_name",
     "collect_host_env",
     "get_preset",
     "transfer_host_configs",
@@ -107,4 +129,6 @@ __all__ = [
     "list_presets",
     "preset_command_names",
     "preset_names",
+    "public_preset_name",
+    "public_preset_names",
 ]

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -426,6 +426,8 @@ class VMConfig(BaseModel):
     Attributes:
         vm_id: Optional unique identifier (lowercase alphanumeric with hyphens).
             If omitted, SmolVM auto-generates one.
+        preset: Canonical name of the preset that created this sandbox, or
+            ``None`` when it was created without a preset or predates tracking.
         vcpu_count: Number of virtual CPUs (1-32).
         memory: Memory size in MiB (128-16384).
         boot_mode: How the guest boots:
@@ -502,6 +504,7 @@ class VMConfig(BaseModel):
             pattern=_IDENTIFIER_PATTERN,
         ),
     ]
+    preset: str | None = None
     vcpu_count: Annotated[int, Field(ge=1, le=32)] = 2
     memory: Annotated[int, Field(ge=128, le=16384)] = 512
     guest_os: GuestOS = GuestOS.ALPINE

--- a/tests/api/test_snapshot.py
+++ b/tests/api/test_snapshot.py
@@ -143,6 +143,7 @@ def test_create_snapshot_pauses_vm_and_persists_metadata(
     tmp_path: Path,
 ) -> None:
     """Snapshot creation should write snapshot metadata and leave the source paused."""
+    sample_config = sample_config.model_copy(update={"preset": "openclaw"})
     _running_vm(smol_vm, sample_config, tmp_path)
     managed_disk = smol_vm.data_dir / "disks" / "vm001.ext4"
     managed_disk.write_text("managed-disk")
@@ -163,6 +164,7 @@ def test_create_snapshot_pauses_vm_and_persists_metadata(
     assert snapshot.snapshot_id == "snap-001"
     assert snapshot.artifacts.disk_path.read_text() == "managed-disk"
     assert persisted.vm_config.rootfs_path == managed_disk
+    assert persisted.vm_config.preset == "openclaw"
     assert smol_vm.get("vm001").status == VMState.PAUSED
     mock_client.pause_vm.assert_called_once()
     mock_client.create_snapshot.assert_called_once()

--- a/tests/api/test_types.py
+++ b/tests/api/test_types.py
@@ -57,6 +57,7 @@ class TestVMConfig:
         )
 
         assert config.vm_id == "vm001"
+        assert config.preset is None
         assert config.vcpu_count == 2
         assert config.memory == 512
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -55,6 +55,7 @@ def _make_vm_info(
     guest_ip: str = "172.16.0.2",
     ssh_host_port: int | None = 2200,
     pid: int | None = 12345,
+    preset: str | None = None,
     workspace_mounts: list[WorkspaceMount] | None = None,
 ) -> MagicMock:
     """Build a lightweight VMInfo-like mock for list tests."""
@@ -62,6 +63,7 @@ def _make_vm_info(
     vm.vm_id = vm_id
     vm.status = status
     vm.pid = pid
+    vm.config.preset = preset
     vm.config.workspace_mounts = workspace_mounts or []
     if guest_ip:
         vm.network = MagicMock(spec=NetworkConfig)
@@ -3133,7 +3135,7 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm sandbox list` should print a Rich table with name, status, and pid."""
+        """`smolvm sandbox list` should show sandbox identity and provenance."""
         vms = [_make_vm_info("vm-abc123", VMState.RUNNING, "172.16.0.2", 2200, 12345)]
         mock_sdk_cls.return_value.list_vms.return_value = vms
 
@@ -3146,6 +3148,7 @@ class TestCliList:
         assert "12345" in out
         assert "SmolVM Instances" in out
         assert "Name" in out
+        assert "Preset" in out
         assert "Status" in out
         assert "PID" in out
         assert "Total: 1 VM(s)." in out
@@ -3221,10 +3224,15 @@ class TestCliList:
         payload = json.loads(capsys.readouterr().out)
         assert payload["command"] == "sandbox.list"
         assert payload["ok"] is True
-        assert payload["data"]["filters"] == {"all": False, "status": "running"}
+        assert payload["data"]["filters"] == {
+            "all": False,
+            "status": "running",
+            "preset": None,
+        }
         assert payload["data"]["vms"] == [
             {
                 "name": "vm-abc123",
+                "preset": None,
                 "status": "running",
                 "ip_address": "172.16.0.2",
                 "ssh_port": 2200,
@@ -3247,7 +3255,11 @@ class TestCliList:
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["vms"] == []
-        assert payload["data"]["filters"] == {"all": False, "status": "running"}
+        assert payload["data"]["filters"] == {
+            "all": False,
+            "status": "running",
+            "preset": None,
+        }
         mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=VMState.RUNNING)
 
     def test_list_all_json(
@@ -3265,11 +3277,157 @@ class TestCliList:
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["data"]["filters"] == {"all": True, "status": None}
+        assert payload["data"]["filters"] == {"all": True, "status": None, "preset": None}
         assert payload["data"]["vms"][0]["name"] == "vm-abc123"
         assert payload["data"]["vms"][1]["status"] == "stopped"
         assert payload["data"]["vms"][1]["ssh_port"] is None
         mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=None)
+
+    def test_list_preset_filters_before_refreshing_status(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Preset filtering uses stored provenance and ignores legacy rows."""
+        openclaw = _make_vm_info("claw", preset="openclaw")
+        codex = _make_vm_info("code", preset="codex")
+        legacy = _make_vm_info("legacy")
+        mock_sdk_cls.return_value.list_vms.return_value = [openclaw, codex, legacy]
+
+        ret = main(["sandbox", "list", "--preset", "openclaw", "--all"])
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "claw" in out
+        assert "openclaw" in out
+        assert "code" not in out
+        assert "legacy" not in out
+        mock_sdk_cls.return_value.refresh_status.assert_called_once_with(openclaw)
+
+    def test_list_preset_alias_uses_canonical_json_value(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The public `claude` spelling filters on canonical provenance."""
+        mock_sdk_cls.return_value.list_vms.return_value = [
+            _make_vm_info("claude-work", preset="claude-code")
+        ]
+
+        ret = main(["sandbox", "list", "--preset", "claude", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["filters"]["preset"] == "claude-code"
+        assert payload["data"]["vms"][0]["preset"] == "claude-code"
+
+    def test_list_preset_uses_public_name_in_human_output(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        mock_sdk_cls.return_value.list_vms.return_value = [
+            _make_vm_info("agent-work", preset="claude-code")
+        ]
+
+        ret = main(["sandbox", "list", "--preset", "claude"])
+
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "claude" in output
+        assert "claude-code" not in output
+
+    def test_list_preset_composes_with_status_filter(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        openclaw = _make_vm_info("claw", VMState.STOPPED, preset="openclaw")
+        codex = _make_vm_info("code", VMState.STOPPED, preset="codex")
+        mock_sdk_cls.return_value.list_vms.return_value = [openclaw, codex]
+
+        ret = main(["sandbox", "list", "--preset", "openclaw", "--status", "stopped", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["filters"] == {
+            "all": False,
+            "status": "stopped",
+            "preset": "openclaw",
+        }
+        assert [row["name"] for row in payload["data"]["vms"]] == ["claw"]
+        mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=VMState.STOPPED)
+
+    def test_openclaw_list_error_reconciles_stale_running_sandboxes(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        stale = _make_vm_info("claw", VMState.RUNNING, preset="openclaw")
+        reconciled = _make_vm_info("claw", VMState.ERROR, preset="openclaw", pid=None)
+        mock_sdk_cls.return_value.list_vms.return_value = [stale]
+        mock_sdk_cls.return_value.refresh_status.side_effect = lambda _vm: reconciled
+
+        ret = main(["openclaw", "list", "--status", "error", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [row["name"] for row in payload["data"]["vms"]] == ["claw"]
+        mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=None)
+        mock_sdk_cls.return_value.refresh_status.assert_called_once_with(stale)
+
+    def test_openclaw_list_matches_the_generic_filter(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        mock_sdk_cls.return_value.list_vms.return_value = [
+            _make_vm_info("claw", preset="openclaw"),
+            _make_vm_info("code", preset="codex"),
+        ]
+
+        ret = main(["openclaw", "list", "--all", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "openclaw.list"
+        assert payload["data"]["filters"]["preset"] == "openclaw"
+        assert [row["name"] for row in payload["data"]["vms"]] == ["claw"]
+
+    @pytest.mark.parametrize(
+        ("argv", "expected"),
+        [
+            (["openclaw", "list"], "No running 'openclaw' sandboxes found."),
+            (["openclaw", "list", "--all"], "No 'openclaw' sandboxes found."),
+            (
+                ["openclaw", "list", "--status", "stopped"],
+                "No 'openclaw' sandboxes with status 'stopped'.",
+            ),
+        ],
+    )
+    def test_openclaw_list_empty_state_names_how_to_create_one(
+        self,
+        argv: list[str],
+        expected: str,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        mock_sdk_cls.return_value.list_vms.return_value = []
+
+        ret = main(argv)
+
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert expected in output
+        assert "smolvm openclaw start" in output
+
+    def test_list_rejects_unknown_preset(self, capsys: pytest.CaptureFixture) -> None:
+        ret = main(["sandbox", "list", "--preset", "unknown"])
+
+        assert ret == 2
+        error = capsys.readouterr().err
+        assert "Invalid value for '--preset'" in error
+        assert "openclaw" in error
 
     def test_list_status_filter_empty(
         self,
@@ -3808,6 +3966,7 @@ class TestCliStart:
         mock_build_auto_config.assert_called_once_with(
             vm_name="sbx-codex",
             name_prefix="codex",
+            preset_name="codex",
             os=GuestOS.UBUNTU,
             backend="qemu",
             qemu_machine="q35",
@@ -3871,6 +4030,7 @@ class TestCliStart:
         assert payload["data"]["preset"]["injected_env_keys"] == ["OPENAI_API_KEY"]
         assert payload["data"]["next"]["shell_command"] == "smolvm sandbox shell sbx-1"
         assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh sbx-1"
+        assert mock_build_auto_config.call_args.kwargs["preset_name"] == "codex"
         assert mock_apply_fn.call_args.kwargs["preset_command"] == "codex"
         assert mock_apply_fn.call_args.kwargs["sandbox_name"] == "sbx-1"
 
@@ -4341,6 +4501,7 @@ class TestOpenClawOpen:
         mock_run.assert_called_once_with(
             include_all=True,
             status_filter=None,
+            preset_filter="openclaw",
             json_output=True,
             command_name="openclaw.list",
         )
@@ -4368,17 +4529,24 @@ class TestOpenClawOpen:
         assert "Seconds to wait for each agent installation step." in normalized_output
 
     @patch("smolvm.cli.main._cli_vm_from_id", side_effect=VMNotFoundError("missing-claw"))
+    @pytest.mark.parametrize("json_output", [False, True])
     def test_open_missing_sandbox_names_recovery_commands(
         self,
         _mock_vm_from_id: MagicMock,
+        json_output: bool,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        ret = main(["openclaw", "open", "missing-claw", "--json"])
+        argv = ["openclaw", "open", "missing-claw"]
+        if json_output:
+            argv.append("--json")
+
+        ret = main(argv)
 
         assert ret == 1
-        error = json.loads(capsys.readouterr().out)["error"]["message"]
+        captured = capsys.readouterr()
+        error = json.loads(captured.out)["error"]["message"] if json_output else captured.err
         assert "Sandbox 'missing-claw' was not found" in error
-        assert "smolvm openclaw list --all" in error
+        assert "smolvm sandbox list --all" in error
         assert "smolvm openclaw start --name missing-claw --no-attach" in error
 
     @patch("smolvm.cli.main._run_openclaw_open", return_value=0)
@@ -5091,6 +5259,7 @@ class TestPublishedImageLaunchPath:
 
         # Verify VMConfig was built with the right wiring.
         config_arg = mock_vm_cls.call_args[0][0]
+        assert config_arg.preset == "openclaw"
         assert config_arg.kernel_path == kernel
         assert config_arg.rootfs_path == rootfs
         assert config_arg.backend == expected_backend

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4326,7 +4326,31 @@ class TestOpenClawOpen:
         ret = main(["openclaw", "--help"])
 
         assert ret == 0
-        assert "open" in capsys.readouterr().out
+        output = capsys.readouterr().out
+        assert "list" in output
+        assert "open" in output
+
+    @patch("smolvm.cli.main._run_list", return_value=0)
+    def test_list_routes_filters_to_the_shared_sandbox_inventory(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        ret = main(["openclaw", "list", "--all", "--json"])
+
+        assert ret == 0
+        mock_run.assert_called_once_with(
+            include_all=True,
+            status_filter=None,
+            json_output=True,
+            command_name="openclaw.list",
+        )
+
+    @patch("smolvm.cli.main._run_list", return_value=0)
+    def test_list_rejects_conflicting_filters(self, mock_run: MagicMock) -> None:
+        ret = main(["openclaw", "list", "--all", "--status", "running"])
+
+        assert ret == 2
+        mock_run.assert_not_called()
 
     def test_start_help_only_offers_supported_os_and_explains_slow_install(
         self, capsys: pytest.CaptureFixture[str]
@@ -4354,7 +4378,7 @@ class TestOpenClawOpen:
         assert ret == 1
         error = json.loads(capsys.readouterr().out)["error"]["message"]
         assert "Sandbox 'missing-claw' was not found" in error
-        assert "smolvm sandbox list --all" in error
+        assert "smolvm openclaw list --all" in error
         assert "smolvm openclaw start --name missing-claw --no-attach" in error
 
     @patch("smolvm.cli.main._run_openclaw_open", return_value=0)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3394,6 +3394,20 @@ class TestCliList:
         assert payload["data"]["filters"]["preset"] == "openclaw"
         assert [row["name"] for row in payload["data"]["vms"]] == ["claw"]
 
+    def test_openclaw_list_omits_the_redundant_preset_column(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        mock_sdk_cls.return_value.list_vms.return_value = [_make_vm_info("claw", preset="openclaw")]
+
+        ret = main(["openclaw", "list"])
+
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "claw" in output
+        assert "Preset" not in output
+
     @pytest.mark.parametrize(
         ("argv", "expected"),
         [
@@ -4502,6 +4516,7 @@ class TestOpenClawOpen:
             include_all=True,
             status_filter=None,
             preset_filter="openclaw",
+            show_preset_column=False,
             json_output=True,
             command_name="openclaw.list",
         )

--- a/tests/presets/test_presets.py
+++ b/tests/presets/test_presets.py
@@ -37,10 +37,13 @@ from smolvm.presets import (
     HostKeychainSecret,
     Preset,
     apply_preset,
+    canonical_preset_name,
     collect_host_env,
     get_preset,
     list_presets,
     preset_names,
+    public_preset_name,
+    public_preset_names,
     transfer_host_env,
 )
 from smolvm.presets._scripts import npm_install_global, uv_install_global
@@ -114,6 +117,19 @@ class TestRegistry:
             match="Available: claude-code, codex, hermes, openclaw, opencode, pi",
         ):
             get_preset("nonexistent")
+
+    def test_public_and_canonical_names_are_consistent(self) -> None:
+        assert public_preset_name("claude-code") == "claude"
+        assert canonical_preset_name("claude") == "claude-code"
+        assert canonical_preset_name("claw") == "openclaw"
+        assert public_preset_names() == [
+            "claude",
+            "codex",
+            "hermes",
+            "openclaw",
+            "opencode",
+            "pi",
+        ]
 
 
 class TestCodexPreset:

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -14,6 +14,7 @@
 
 """Tests for SmolVM storage module."""
 
+import json
 import os
 import sqlite3
 from datetime import UTC, datetime
@@ -96,6 +97,33 @@ class TestStateManagerVMOperations:
 
         assert vm_info.vm_id == "vm001"
         assert vm_info.status == VMState.CREATED
+
+    def test_get_vm_preserves_preset_provenance(
+        self,
+        state_manager: StateManager,
+        sample_config: VMConfig,
+    ) -> None:
+        config = sample_config.model_copy(update={"preset": "openclaw"})
+        state_manager.create_vm(config)
+
+        assert state_manager.get_vm("vm001").config.preset == "openclaw"
+
+    def test_get_legacy_vm_without_preset_defaults_to_none(
+        self,
+        state_manager: StateManager,
+        sample_config: VMConfig,
+    ) -> None:
+        state_manager.create_vm(sample_config)
+        with sqlite3.connect(state_manager.db_path) as conn:
+            raw = conn.execute("SELECT config FROM vms WHERE id = 'vm001'").fetchone()[0]
+            legacy_config = json.loads(raw)
+            legacy_config.pop("preset")
+            conn.execute(
+                "UPDATE vms SET config = ? WHERE id = 'vm001'",
+                (json.dumps(legacy_config),),
+            )
+
+        assert state_manager.get_vm("vm001").config.preset is None
 
     def test_get_vm_allows_missing_persisted_paths(
         self,

--- a/tests/vm/test_facade.py
+++ b/tests/vm/test_facade.py
@@ -382,6 +382,7 @@ class TestVMInit:
         config, _ = _build_auto_config(
             os="ubuntu",
             backend=backend,
+            preset_name="codex",
             on_download=on_download,
         )
 
@@ -390,6 +391,7 @@ class TestVMInit:
         assert mock_ensure_published.call_args.kwargs["on_download"] is on_download
 
         assert config.backend == backend
+        assert config.preset == "codex"
         assert config.guest_os is GuestOS.UBUNTU
         assert config.rootfs_path == rootfs
         assert config.rootfs_format == "raw-ext4"
@@ -573,9 +575,13 @@ class TestVMInit:
         mock_builder.build_alpine_ssh_key.return_value = (kernel, rootfs)
         mock_builder_cls.return_value = mock_builder
 
-        config, ssh_key_path = _build_auto_config(vm_name="project-spacex")
+        config, ssh_key_path = _build_auto_config(
+            vm_name="project-spacex",
+            preset_name="openclaw",
+        )
 
         assert config.vm_id == "project-spacex"
+        assert config.preset == "openclaw"
         assert ssh_key_path == str(private_key)
         assert config.guest_managed_networking is True
         assert "init=/init" in config.boot_args


### PR DESCRIPTION
## Summary

- Add `smolvm openclaw list` for finding running OpenClaw sandboxes, with a compact `NAME` / `STATUS` / `PID` table plus `--all`, `--status`, and `--json` support.
- Add the generic `smolvm sandbox list --preset PRESET` filter and show preset provenance in human and JSON listings.
- Persist canonical preset provenance for newly created preset sandboxes while keeping legacy and manually prepared sandboxes available through the unfiltered inventory.
- Reconcile stale running or paused records before returning `--status error`, so crashed sandboxes are not silently omitted.

## Related Issues

No linked issue.

## Testing

- `uv run pytest tests/api/test_types.py tests/api/test_snapshot.py tests/cli/test_cli.py tests/presets/test_presets.py tests/storage/test_storage.py tests/vm/test_facade.py -q` — 673 passed, 8 skipped.
- `uv run pytest tests/cli/test_cli.py -q` — 310 passed after simplifying the OpenClaw-specific table.
- `uv run pytest -q` — 2,123 passed, 21 skipped, 30 deselected; 3 unrelated local-environment failures remain because port 2200 is occupied and stale ignored native-extension artifacts are present.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed.
- CLI help smoke-tested for both new list surfaces.
- `uv run mypy src` — repository baseline remains non-clean with 191 existing errors; no error points to a changed line in this feature.

## Pre-Landing Review

- Fixed the review finding so a missing OpenClaw sandbox points to `smolvm sandbox list --all`, which includes legacy and manually prepared sandboxes.
- Added missing provenance and empty-state coverage, removed a duplicate preset exposure allowlist, and fixed stale `error` status reconciliation.
- Security, performance, API-contract, and final red-team reviews found no unresolved issues.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

All 8 planned implementation items are complete. Package release and image publishing remain separate follow-up work.

## Documentation

- `README.md`: shows the compact `smolvm openclaw list` output and dashboard workflow.
- `docs/guides/agent-presets.md`: documents both filtered-list commands, `--all`, `--status`, and legacy sandbox behavior.
- `docs/reference/cli.md`: covers the generic `--preset` filter and OpenClaw-specific equivalent.

Coverage: all shipped listing and preset-provenance behavior has adequate reference and how-to documentation. No architecture diagram drift found.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added or updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preset-aware sandbox listings, including `--preset` filtering and a visible Preset column.
  * Added `smolvm openclaw list` with status filtering and support for showing all sandboxes.
  * Added OpenClaw listing guidance and expanded CLI documentation.
  * Preset names and aliases are now recognized consistently across commands.

* **Bug Fixes**
  * Preset information is now retained when creating, storing, and restoring sandboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->