### PR TITLE
fix: polish OpenClaw listing experience

### DIFF
--- a/docs/guides/agent-presets.md
+++ b/docs/guides/agent-presets.md
@@ -40,7 +40,7 @@ smolvm openclaw list
 # openclaw-work     running  12345
 ```
 
-This command shows running sandboxes created by the OpenClaw preset. Add `--all` to include stopped OpenClaw sandboxes, or `--status STATUS` to choose one state.
+This command shows running OpenClaw sandboxes. Add `--all` to include every state, or `--status STATUS` to choose one state.
 
 Use the generic preset filter when you are working with the full sandbox inventory:
 
@@ -50,7 +50,7 @@ smolvm sandbox list --preset openclaw
 # openclaw-work     openclaw   running  12345
 ```
 
-Sandboxes created before preset tracking do not appear in either filtered list. They remain available through `smolvm sandbox list --all`, where the Preset column shows `-`.
+Sandboxes created by older SmolVM releases do not appear in either filtered list. Manually prepared sandboxes are also excluded. Both remain available through `smolvm sandbox list --all`, where the Preset column shows `-`.
 
 Then open its private dashboard through a localhost-only connection:
 
@@ -117,4 +117,4 @@ Review `doctor` output before running its repair mode. OpenClaw can follow works
 
 ## Implementation notes
 
-The command registry is in [`src/smolvm/presets/__init__.py`](../../src/smolvm/presets/__init__.py). Each preset declares its installer, forwarded environment variables, and copied files: [Codex](../../src/smolvm/presets/codex.py), [Claude Code](../../src/smolvm/presets/claude_code.py), [Pi](../../src/smolvm/presets/pi.py), [Hermes](../../src/smolvm/presets/hermes.py), [OpenClaw](../../src/smolvm/presets/openclaw.py), and [OpenCode](../../src/smolvm/presets/opencode.py). Preset behavior is covered in [`tests/test_presets.py`](../../tests/test_presets.py).
+The command registry is in [`src/smolvm/presets/__init__.py`](../../src/smolvm/presets/__init__.py). Each preset declares its installer, forwarded environment variables, and copied files: [Codex](../../src/smolvm/presets/codex.py), [Claude Code](../../src/smolvm/presets/claude_code.py), [Pi](../../src/smolvm/presets/pi.py), [Hermes](../../src/smolvm/presets/hermes.py), [OpenClaw](../../src/smolvm/presets/openclaw.py), and [OpenCode](../../src/smolvm/presets/opencode.py). Preset behavior is covered in [`tests/presets/test_presets.py`](../../tests/presets/test_presets.py).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,9 +51,9 @@ Run these in the order you need them:
 `smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, `smolvm openclaw start`, and `smolvm opencode start` each create a sandbox and install that agent.
 
 - Create and install OpenClaw with `smolvm openclaw start`.
-- Find an OpenClaw sandbox with `smolvm openclaw list`, or use the generic `smolvm sandbox list --preset openclaw`. Add `--all` to include stopped sandboxes or `--status STATUS` to choose one state.
+- Find an OpenClaw sandbox with `smolvm openclaw list`, or use the generic `smolvm sandbox list --preset openclaw`. Add `--all` to include every state or `--status STATUS` to choose one state.
 - Open the dashboard with `smolvm openclaw open SANDBOX`. It starts or reuses the gateway and connects it over localhost only. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output.
-- Sandboxes created before preset tracking remain visible in unfiltered sandbox listings but are excluded from preset-filtered results.
+- Sandboxes created by older SmolVM releases and manually prepared sandboxes remain visible through `smolvm sandbox list --all`, but they do not appear in filtered results.
 - The current OpenClaw fallback installation can take several minutes. See [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
 
 ## Manage downloaded images
@@ -111,4 +111,4 @@ smolvm completion fish > ~/.config/fish/completions/smolvm.fish
 
 `--json` is available on commands that return structured output. `--backend` selects `auto`, `firecracker`, `qemu`, `libkrun`, or `vz` where the command supports that runtime. The `vz` choice is only for macOS guests on Apple Silicon. `--boot-timeout` controls how long an operation waits for a ready sandbox.
 
-**Implementation notes:** the command definitions are the source of truth in [`src/smolvm/cli/commands/app.py`](../../src/smolvm/cli/commands/app.py), including available flags and help text. The CLI command surface is tested by [`tests/test_cli.py`](../../tests/test_cli.py).
+**Implementation notes:** the command definitions are the source of truth in [`src/smolvm/cli/commands/app.py`](../../src/smolvm/cli/commands/app.py), including available flags and help text. The CLI command surface is tested by [`tests/cli/test_cli.py`](../../tests/cli/test_cli.py).

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -1603,13 +1603,19 @@ def _register_preset_commands() -> None:
         )
         if preset.name == "openclaw":
 
-            @click.command("list", help="List sandboxes created by the OpenClaw preset.")
-            @click.option("--all", "include_all", is_flag=True, help="Show all sandboxes.")
+            @click.command("list", help="List your OpenClaw sandboxes.")
+            @click.option(
+                "--all",
+                "include_all",
+                is_flag=True,
+                help="Include OpenClaw sandboxes in every state.",
+            )
             @click.option(
                 "--status",
                 "status_filter",
                 type=click.Choice([state.value for state in VMState]),
                 default=None,
+                help="Show only OpenClaw sandboxes in this state.",
             )
             @json_option
             def openclaw_list(
@@ -1617,7 +1623,7 @@ def _register_preset_commands() -> None:
                 status_filter: str | None,
                 json_output: bool,
             ) -> Any:
-                """List sandboxes created by the OpenClaw preset."""
+                """List your OpenClaw sandboxes."""
                 if include_all and status_filter is not None:
                     raise click.UsageError(
                         "Use one filter. Run 'smolvm openclaw list --all' or "
@@ -1633,7 +1639,7 @@ def _register_preset_commands() -> None:
                     command_name="openclaw.list",
                 )
 
-            @click.command("open", help="Open this sandbox's OpenClaw dashboard.")
+            @click.command("open", help="Open an OpenClaw sandbox's dashboard.")
             @click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
             @click.option(
                 "--host-port",

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -664,7 +664,18 @@ def _run_list(
                         message = f"No '{public_name}' sandboxes found."
                     else:
                         message = f"No running '{public_name}' sandboxes found."
-                    message += f" Run 'smolvm {public_name} start'."
+                    if include_all:
+                        message += (
+                            "\nOlder or manually prepared: 'smolvm sandbox list --all'."
+                            f"\nCreate one: 'smolvm {public_name} start'."
+                        )
+                    else:
+                        filtered_list_command = (
+                            f"smolvm {public_name} list"
+                            if command_name == f"{public_name}.list"
+                            else f"smolvm sandbox list --preset {public_name}"
+                        )
+                        message += f"\nOther states: '{filtered_list_command} --all'."
                 elif status_filter:
                     message = f"No VMs found with status '{status_filter}'."
                 elif include_all:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -666,8 +666,9 @@ def _run_list(
                         message = f"No running '{public_name}' sandboxes found."
                     if include_all:
                         message += (
-                            "\nOlder or manually prepared: 'smolvm sandbox list --all'."
-                            f"\nCreate one: 'smolvm {public_name} start'."
+                            "\nTo include older or manually prepared sandboxes, run"
+                            "\n'smolvm sandbox list --all'; to create one, run "
+                            f"'smolvm {public_name} start'."
                         )
                     else:
                         filtered_list_command = (

--- a/src/smolvm/presets/openclaw.py
+++ b/src/smolvm/presets/openclaw.py
@@ -25,7 +25,7 @@ OPENCLAW_NODE_VERSION = (24, 15, 0)
 OPENCLAW_PRESET = Preset(
     name="openclaw",
     aliases=("claw",),
-    summary="Start a sandbox with the OpenClaw CLI preinstalled.",
+    summary="Create and manage OpenClaw sandboxes.",
     setup_script=node_bootstrap(24, minimum_version=OPENCLAW_NODE_VERSION),
     install_script=npm_install_global(
         "openclaw",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3409,20 +3409,30 @@ class TestCliList:
         assert "Preset" not in output
 
     @pytest.mark.parametrize(
-        ("argv", "expected"),
+        ("argv", "expected", "expected_recoveries"),
         [
-            (["openclaw", "list"], "No running 'openclaw' sandboxes found."),
-            (["openclaw", "list", "--all"], "No 'openclaw' sandboxes found."),
+            (
+                ["openclaw", "list"],
+                "No running 'openclaw' sandboxes found.",
+                ("smolvm openclaw list --all",),
+            ),
+            (
+                ["openclaw", "list", "--all"],
+                "No 'openclaw' sandboxes found.",
+                ("smolvm sandbox list --all", "smolvm openclaw start"),
+            ),
             (
                 ["openclaw", "list", "--status", "stopped"],
                 "No 'openclaw' sandboxes with status 'stopped'.",
+                ("smolvm openclaw list --all",),
             ),
         ],
     )
-    def test_openclaw_list_empty_state_names_how_to_create_one(
+    def test_openclaw_list_empty_state_names_recovery(
         self,
         argv: list[str],
         expected: str,
+        expected_recoveries: tuple[str, ...],
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
@@ -3431,9 +3441,24 @@ class TestCliList:
         ret = main(argv)
 
         assert ret == 0
-        output = capsys.readouterr().out
+        output = " ".join(capsys.readouterr().out.split())
         assert expected in output
-        assert "smolvm openclaw start" in output
+        for recovery in expected_recoveries:
+            assert recovery in output
+
+    def test_generic_preset_empty_state_uses_generic_list_recovery(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        mock_sdk_cls.return_value.list_vms.return_value = []
+
+        ret = main(["sandbox", "list", "--preset", "codex"])
+
+        assert ret == 0
+        output = " ".join(capsys.readouterr().out.split())
+        assert "smolvm sandbox list --preset codex --all" in output
+        assert "smolvm codex list" not in output
 
     def test_list_rejects_unknown_preset(self, capsys: pytest.CaptureFixture) -> None:
         ret = main(["sandbox", "list", "--preset", "unknown"])
@@ -4493,16 +4518,28 @@ class TestCliStart:
         mock_subprocess_run.assert_not_called()
 
 
-class TestOpenClawOpen:
-    """Tests for ``smolvm openclaw open``."""
+class TestOpenClawCommands:
+    """Tests for OpenClaw-specific commands."""
 
-    def test_openclaw_help_lists_open_action(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_openclaw_help_describes_available_actions(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         ret = main(["openclaw", "--help"])
 
         assert ret == 0
         output = capsys.readouterr().out
+        assert "Create and manage OpenClaw sandboxes." in output
         assert "list" in output
         assert "open" in output
+
+    def test_openclaw_list_help_explains_filters(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ret = main(["openclaw", "list", "--help"])
+
+        assert ret == 0
+        output = " ".join(capsys.readouterr().out.split())
+        assert "List your OpenClaw sandboxes." in output
+        assert "Include OpenClaw sandboxes in every state." in output
+        assert "Show only OpenClaw sandboxes in this state." in output
 
     @patch("smolvm.cli.main._run_list", return_value=0)
     def test_list_routes_filters_to_the_shared_sandbox_inventory(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3419,7 +3419,10 @@ class TestCliList:
             (
                 ["openclaw", "list", "--all"],
                 "No 'openclaw' sandboxes found.",
-                ("smolvm sandbox list --all", "smolvm openclaw start"),
+                (
+                    "To include older or manually prepared sandboxes, run",
+                    "'smolvm sandbox list --all'; to create one, run 'smolvm openclaw start'.",
+                ),
             ),
             (
                 ["openclaw", "list", "--status", "stopped"],


### PR DESCRIPTION
## Summary

- Make empty preset-filtered listings guide users through other states, then the legacy inventory, before suggesting a new sandbox.
- Rewrite the OpenClaw command help around the resource and explain both list filters.
- Clarify legacy and manually prepared sandbox behavior in the guide and CLI reference.
- Clean up stale OpenClaw test names and repair two outdated test-file links in the documentation.

## Related Issues

Follow-up to #486.

## Testing

- `uv run pytest tests/cli/test_cli.py -q` — 312 passed.
- `uv run pytest tests/api/test_types.py tests/api/test_snapshot.py tests/cli/test_cli.py tests/presets/test_presets.py tests/storage/test_storage.py tests/vm/test_facade.py -q` — 676 passed, 8 skipped.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed.
- Live CLI help and all OpenClaw empty-state recovery paths smoke-tested in an isolated data directory.

## Release follow-up

- [ ] Update the separate `CelestoAI/mintlify-docs` repository before the next SmolVM package release. Its `smolvm/cli/list.mdx` page still omits `--preset` and the new JSON fields, and `smolvm/features/coding-agents.mdx` still omits the OpenClaw workflow.

## Checklist

- [x] Scope is focused and limited to the DevEx review findings
- [x] Tests added or updated for behavior changes
- [x] In-repository documentation updated
- [x] Unrelated local worktree changes excluded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that `--all` displays OpenClaw sandboxes in every state.
  - Explained how older-version and manually prepared sandboxes appear in filtered and complete listings.
  - Documented OpenClaw dashboard connection behavior and updated CLI test references.

- **User Experience**
  - Improved OpenClaw command descriptions for listing, filtering, and opening dashboards.
  - Expanded empty-list guidance with context-specific recovery suggestions.
  - Updated the OpenClaw preset summary to describe creating and managing sandboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->