### PR TITLE
fix: start OpenClaw sandboxes with fresh configuration

### DIFF
--- a/docs/guides/agent-presets.md
+++ b/docs/guides/agent-presets.md
@@ -104,16 +104,14 @@ OpenCode supports multiple providers. You can forward common provider keys such 
 
 Presets copy only the configuration they need where possible. Review what you put in host configuration folders before starting a sandbox, especially when they contain credentials.
 
-For OpenClaw, SmolVM copies `~/.openclaw/openclaw.json` and `~/.openclaw/.env` when they exist. It does not copy the whole state directory because OpenClaw 2.0 keeps device and session state in SQLite databases that should not be duplicated into a disposable sandbox. SmolVM also forwards `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENCLAW_GATEWAY_TOKEN`, and `OPENCLAW_GATEWAY_PASSWORD` when set.
+OpenClaw is an exception: every new OpenClaw sandbox starts with a fresh configuration. SmolVM does not copy `~/.openclaw/openclaw.json`, `~/.openclaw/.env`, or any other OpenClaw state from your machine. It forwards `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENCLAW_GATEWAY_TOKEN`, and `OPENCLAW_GATEWAY_PASSWORD` only when those variables are set in the shell that starts SmolVM.
 
-If OpenClaw reports a configuration problem, enter the sandbox and inspect it before applying repairs:
+Run onboarding inside the sandbox when you need configuration beyond those credentials:
 
 ```bash
 smolvm sandbox shell openclaw-work
-openclaw doctor
+openclaw onboard
 ```
-
-Review `doctor` output before running its repair mode. OpenClaw can follow workspace or storage paths named in copied configuration, so a repair may change data outside `~/.openclaw`.
 
 ## Implementation notes
 

--- a/examples/openclaw.py
+++ b/examples/openclaw.py
@@ -3,7 +3,7 @@
 
 For everyday use, prefer ``smolvm openclaw start`` followed by
 ``smolvm openclaw open``. This lower-level example shows the same runtime,
-safe configuration transfer, and localhost-only dashboard flow with the SDK.
+explicit credential forwarding, and localhost-only dashboard flow with the SDK.
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from smolvm import SSH_BOOT_ARGS, ImageBuilder, SmolVM, VMConfig
@@ -47,23 +46,6 @@ def _host_env_vars() -> dict[str, str]:
         "OPENCLAW_GATEWAY_PASSWORD",
     )
     return {name: value for name in names if (value := os.getenv(name, "").strip())}
-
-
-def _copy_portable_config(vm: SmolVM) -> None:
-    """Copy config files, but leave OpenClaw's SQLite state on the host."""
-    source_dir = Path.home() / ".openclaw"
-    copies = (
-        (source_dir / "openclaw.json", "/root/.openclaw/openclaw.json"),
-        (source_dir / ".env", "/root/.openclaw/.env"),
-    )
-    available = [(source, target) for source, target in copies if source.is_file()]
-    if not available:
-        return
-
-    _run_or_exit(vm, "mkdir -p /root/.openclaw", timeout=30)
-    for source, target in available:
-        vm.upload_file(source, target)
-        _run_or_exit(vm, f"chmod 600 {target}", timeout=30)
 
 
 def _install_supported_node(vm: SmolVM) -> None:
@@ -189,7 +171,6 @@ def main() -> int:
         print(f"Sandbox running: {vm.vm_id} ({vm.get_ip()})")
         _install_supported_node(vm)
         _install_openclaw(vm)
-        _copy_portable_config(vm)
         if env_vars:
             vm.set_env_vars(env_vars)
         _start_gateway(vm)

--- a/src/smolvm/presets/openclaw.py
+++ b/src/smolvm/presets/openclaw.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from smolvm.presets._scripts import node_bootstrap, npm_install_global
-from smolvm.presets._types import HostConfigCopy, Preset
+from smolvm.presets._types import Preset
 
 OPENCLAW_VERSION = "2026.9.1"
 OPENCLAW_NODE_VERSION = (24, 15, 0)
@@ -38,18 +38,6 @@ OPENCLAW_PRESET = Preset(
         "OPENAI_API_KEY",
         "OPENCLAW_GATEWAY_TOKEN",
         "OPENCLAW_GATEWAY_PASSWORD",
-    ),
-    host_configs=(
-        HostConfigCopy(
-            host_path="~/.openclaw/openclaw.json",
-            guest_path="/root/.openclaw/openclaw.json",
-            file_mode=0o600,
-        ),
-        HostConfigCopy(
-            host_path="~/.openclaw/.env",
-            guest_path="/root/.openclaw/.env",
-            file_mode=0o600,
-        ),
     ),
     supported_oses=("ubuntu",),
     # The current published image predates OpenClaw 2.0. Keep users on the

--- a/tests/presets/test_presets.py
+++ b/tests/presets/test_presets.py
@@ -478,8 +478,6 @@ class TestOpenClawPreset:
             "OPENCLAW_GATEWAY_TOKEN",
             "OPENCLAW_GATEWAY_PASSWORD",
         )
-
-    def test_openclaw_starts_without_host_config_files(self) -> None:
         assert OPENCLAW_PRESET.host_configs == ()
 
     def test_openclaw_install_is_pinned_and_allows_lifecycle_scripts(self) -> None:

--- a/tests/presets/test_presets.py
+++ b/tests/presets/test_presets.py
@@ -479,13 +479,8 @@ class TestOpenClawPreset:
             "OPENCLAW_GATEWAY_PASSWORD",
         )
 
-    def test_openclaw_copies_only_portable_config_files(self) -> None:
-        pairs = [(cfg.host_path, cfg.guest_path) for cfg in OPENCLAW_PRESET.host_configs]
-        assert pairs == [
-            ("~/.openclaw/openclaw.json", "/root/.openclaw/openclaw.json"),
-            ("~/.openclaw/.env", "/root/.openclaw/.env"),
-        ]
-        assert all(cfg.file_mode == 0o600 for cfg in OPENCLAW_PRESET.host_configs)
+    def test_openclaw_starts_without_host_config_files(self) -> None:
+        assert OPENCLAW_PRESET.host_configs == ()
 
     def test_openclaw_install_is_pinned_and_allows_lifecycle_scripts(self) -> None:
         from smolvm.presets.openclaw import OPENCLAW_VERSION

--- a/tests/windows/test_examples.py
+++ b/tests/windows/test_examples.py
@@ -113,6 +113,15 @@ def test_openclaw_example_handles_custom_ports_and_tls_config() -> None:
     assert "parsed.port != GUEST_DASHBOARD_PORT" in source
 
 
+def test_openclaw_example_starts_without_host_config_files() -> None:
+    """The SDK example should preserve the CLI's fresh-sandbox boundary."""
+    source = (TOP_LEVEL_EXAMPLES_DIR / "openclaw.py").read_text(encoding="utf-8")
+
+    assert "_copy_portable_config" not in source
+    assert "~/.openclaw/openclaw.json" not in source
+    assert "~/.openclaw/.env" not in source
+
+
 def test_langchain_tool_import_without_pydantic_v1_warning() -> None:
     """Import the LangChain shell example without triggering Python 3.14 warnings."""
     path = AGENT_TOOL_EXAMPLES_DIR / "langchain_tool.py"

--- a/tests/windows/test_examples.py
+++ b/tests/windows/test_examples.py
@@ -113,15 +113,6 @@ def test_openclaw_example_handles_custom_ports_and_tls_config() -> None:
     assert "parsed.port != GUEST_DASHBOARD_PORT" in source
 
 
-def test_openclaw_example_starts_without_host_config_files() -> None:
-    """The SDK example should preserve the CLI's fresh-sandbox boundary."""
-    source = (TOP_LEVEL_EXAMPLES_DIR / "openclaw.py").read_text(encoding="utf-8")
-
-    assert "_copy_portable_config" not in source
-    assert "~/.openclaw/openclaw.json" not in source
-    assert "~/.openclaw/.env" not in source
-
-
 def test_langchain_tool_import_without_pydantic_v1_warning() -> None:
     """Import the LangChain shell example without triggering Python 3.14 warnings."""
     path = AGENT_TOOL_EXAMPLES_DIR / "langchain_tool.py"


### PR DESCRIPTION
## Summary
- Stop copying `~/.openclaw/openclaw.json` and `~/.openclaw/.env` into new OpenClaw sandboxes.
- Keep supported API keys and gateway credentials available only through explicitly exported environment variables.
- Align the lower-level OpenClaw SDK example and documentation with the same fresh-sandbox boundary.

## Why
A host config written by OpenClaw 2026.6.10 contained `meta.lastTouchedAt`. SmolVM copied it unchanged into a sandbox running pinned OpenClaw 2026.9.1, which rejected the field and prevented setup. OpenClaw configuration is version-specific and should not silently cross the sandbox boundary.

## Validation
- `uv run pytest tests/presets/test_presets.py tests/windows/test_examples.py tests/cli/test_cli.py -q` (438 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

## Documentation
- Updated the in-repo preset guide.
- Updated CelestoAI/mintlify-docs#154 with the fresh-configuration behavior.

## Release note
This changes newly created sandboxes and requires the next SmolVM package release. Existing OpenClaw sandboxes are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - New OpenClaw sandboxes start with fresh configuration and no longer copy OpenClaw configuration files from the host.
  - Configure OpenClaw inside the sandbox with `openclaw onboard`.
  - Credential forwarding remains available for supported credentials.

- **Documentation**
  - Updated OpenClaw setup and troubleshooting guidance to reflect the new configuration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->