### PR TITLE
feat(cli): rename OpenClaw dashboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ smolvm openclaw list
 # NAME              STATUS   PID
 # openclaw-work     running  12345
 
-smolvm openclaw open openclaw-work
+smolvm openclaw open-ui openclaw-work
 ```
 
 Creating an OpenClaw sandbox currently takes several minutes while SmolVM installs its supported Node.js runtime and pinned OpenClaw release. See the [OpenClaw guide](docs/guides/agent-presets.md#open-openclaws-dashboard) for credentials, the dashboard flow, and safe steps for replacing an older sandbox.

--- a/docs/guides/agent-presets.md
+++ b/docs/guides/agent-presets.md
@@ -55,16 +55,16 @@ Sandboxes created by older SmolVM releases do not appear in either filtered list
 Then open its private dashboard through a localhost-only connection:
 
 ```bash
-smolvm openclaw open openclaw-work
+smolvm openclaw open-ui openclaw-work
 ```
 
 SmolVM starts the OpenClaw gateway if needed, creates a local port forward, and opens the one-time dashboard link in your browser. If you are working on a remote or headless machine, print the link instead:
 
 ```bash
-smolvm openclaw open openclaw-work --no-browser
+smolvm openclaw open-ui openclaw-work --no-browser
 ```
 
-Close the local connection with the exact command printed by `openclaw open`. You can also list active connections with `smolvm sandbox port list openclaw-work`.
+Close the local connection with the exact command printed by `openclaw open-ui`. You can also list active connections with `smolvm sandbox port list openclaw-work`.
 
 OpenClaw currently supports Ubuntu sandboxes in SmolVM.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,7 +52,7 @@ Run these in the order you need them:
 
 - Create and install OpenClaw with `smolvm openclaw start`.
 - Find an OpenClaw sandbox with `smolvm openclaw list`, or use the generic `smolvm sandbox list --preset openclaw`. Add `--all` to include every state or `--status STATUS` to choose one state.
-- Open the dashboard with `smolvm openclaw open SANDBOX`. It starts or reuses the gateway and connects it over localhost only. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output.
+- Open the dashboard with `smolvm openclaw open-ui SANDBOX`. It starts or reuses the gateway and connects it over localhost only. Add `--host-port PORT` to choose the dashboard's local port, `--no-browser` to print the one-time link, or `--json` for structured output.
 - Sandboxes created by older SmolVM releases and manually prepared sandboxes remain visible through `smolvm sandbox list --all`, but they do not appear in filtered results.
 - The current OpenClaw fallback installation can take several minutes. See [Agent presets](../guides/agent-presets.md#open-openclaws-dashboard) for the complete workflow and safe upgrade steps.
 

--- a/examples/openclaw.py
+++ b/examples/openclaw.py
@@ -2,7 +2,7 @@
 """Run OpenClaw 2026.9.1 in a disposable SmolVM sandbox.
 
 For everyday use, prefer ``smolvm openclaw start`` followed by
-``smolvm openclaw open``. This lower-level example shows the same runtime,
+``smolvm openclaw open-ui``. This lower-level example shows the same runtime,
 explicit credential forwarding, and localhost-only dashboard flow with the SDK.
 """
 

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -1639,7 +1639,7 @@ def _register_preset_commands() -> None:
                     command_name="openclaw.list",
                 )
 
-            @click.command("open", help="Open an OpenClaw sandbox's dashboard.")
+            @click.command("open-ui", help="Open an OpenClaw sandbox's dashboard.")
             @click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
             @click.option(
                 "--host-port",
@@ -1655,7 +1655,7 @@ def _register_preset_commands() -> None:
             @ssh_auth_options
             @comm_channel_option
             @json_option
-            def openclaw_open(
+            def openclaw_open_ui(
                 vm_id: str,
                 host_port: int | None,
                 no_browser: bool,
@@ -1665,9 +1665,9 @@ def _register_preset_commands() -> None:
                 json_output: bool,
             ) -> Any:
                 _before_command(json_output=json_output)
-                return _handlers()._run_openclaw_open(
+                return _handlers()._run_openclaw_open_ui(
                     _ns(
-                        command_name="openclaw.open",
+                        command_name="openclaw.open-ui",
                         vm_id=vm_id,
                         host_port=host_port,
                         no_browser=no_browser,
@@ -1679,7 +1679,7 @@ def _register_preset_commands() -> None:
                 )
 
             preset_group.add_command(openclaw_list)
-            preset_group.add_command(openclaw_open)
+            preset_group.add_command(openclaw_open_ui)
         cli.add_command(preset_group)
 
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -198,8 +198,8 @@ class StartPayload(TypedDict):
     next: CreateNextPayload
 
 
-class OpenClawOpenPayload(TypedDict):
-    """Machine-readable result for ``smolvm openclaw open``."""
+class OpenClawOpenUiPayload(TypedDict):
+    """Machine-readable result for ``smolvm openclaw open-ui``."""
 
     sandbox: str
     guest_port: int
@@ -3457,12 +3457,12 @@ exit 1
         )
 
 
-def _run_openclaw_open(args: SimpleNamespace) -> int:
+def _run_openclaw_open_ui(args: SimpleNamespace) -> int:
     """Open the OpenClaw 2.0 dashboard for a running sandbox."""
     import json
     from urllib.parse import urlsplit, urlunsplit
 
-    command_name = getattr(args, "command_name", "openclaw.open")
+    command_name = getattr(args, "command_name", "openclaw.open-ui")
     vm: FacadeVM | None = None
     host_port: int | None = None
     forward_active = False
@@ -3565,7 +3565,7 @@ def _run_openclaw_open(args: SimpleNamespace) -> int:
         close_command = (
             f"smolvm sandbox port close {args.vm_id} {host_port}:{OPENCLAW_DASHBOARD_PORT}"
         )
-        data: OpenClawOpenPayload = {
+        data: OpenClawOpenUiPayload = {
             "sandbox": args.vm_id,
             "guest_port": OPENCLAW_DASHBOARD_PORT,
             "host_port": host_port,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4533,7 +4533,7 @@ class TestOpenClawCommands:
         output = capsys.readouterr().out
         assert "Create and manage OpenClaw sandboxes." in output
         assert "list" in output
-        assert "open" in output
+        assert "open-ui" in output
 
     def test_openclaw_list_help_explains_filters(self, capsys: pytest.CaptureFixture[str]) -> None:
         ret = main(["openclaw", "list", "--help"])
@@ -4583,15 +4583,23 @@ class TestOpenClawCommands:
         assert "Sandbox name; SmolVM generates one when omitted." in normalized_output
         assert "Seconds to wait for each agent installation step." in normalized_output
 
+    def test_open_command_has_been_replaced_by_open_ui(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        ret = main(["openclaw", "open", "sbx-claw"])
+
+        assert ret == 2
+        assert "No such command 'open'" in capsys.readouterr().err
+
     @patch("smolvm.cli.main._cli_vm_from_id", side_effect=VMNotFoundError("missing-claw"))
     @pytest.mark.parametrize("json_output", [False, True])
-    def test_open_missing_sandbox_names_recovery_commands(
+    def test_open_ui_missing_sandbox_names_recovery_commands(
         self,
         _mock_vm_from_id: MagicMock,
         json_output: bool,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        argv = ["openclaw", "open", "missing-claw"]
+        argv = ["openclaw", "open-ui", "missing-claw"]
         if json_output:
             argv.append("--json")
 
@@ -4604,12 +4612,12 @@ class TestOpenClawCommands:
         assert "smolvm sandbox list --all" in error
         assert "smolvm openclaw start --name missing-claw --no-attach" in error
 
-    @patch("smolvm.cli.main._run_openclaw_open", return_value=0)
-    def test_open_routes_options_to_handler(self, mock_run: MagicMock) -> None:
+    @patch("smolvm.cli.main._run_openclaw_open_ui", return_value=0)
+    def test_open_ui_routes_options_to_handler(self, mock_run: MagicMock) -> None:
         ret = main(
             [
                 "openclaw",
-                "open",
+                "open-ui",
                 "sbx-claw",
                 "--host-port",
                 "19876",
@@ -4653,7 +4661,7 @@ class TestOpenClawCommands:
         vm.expose_local.return_value = 39876
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw"])
+        ret = main(["openclaw", "open-ui", "sbx-claw"])
 
         assert ret == 0
         mock_browser_open.assert_called_once_with("http://127.0.0.1:39876/#token=one-time-secret")
@@ -4698,12 +4706,13 @@ class TestOpenClawCommands:
         vm.expose_local.return_value = 39877
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw", "--json"])
+        ret = main(["openclaw", "open-ui", "sbx-claw", "--json"])
 
         assert ret == 0
         mock_browser_open.assert_not_called()
         mock_track.assert_called_once()
         payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "openclaw.open-ui"
         assert payload["data"] == {
             "sandbox": "sbx-claw",
             "guest_port": 18789,
@@ -4744,7 +4753,7 @@ class TestOpenClawCommands:
         vm.expose_local.return_value = 39876
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw", "--no-browser"])
+        ret = main(["openclaw", "open-ui", "sbx-claw", "--no-browser"])
 
         assert ret == 0
         mock_browser_open.assert_not_called()
@@ -4768,7 +4777,7 @@ class TestOpenClawCommands:
         ]
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw", "--json"])
+        ret = main(["openclaw", "open-ui", "sbx-claw", "--json"])
 
         assert ret == 1
         message = json.loads(capsys.readouterr().out)["error"]["message"]
@@ -4797,7 +4806,7 @@ class TestOpenClawCommands:
         ]
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw", "--json"])
+        ret = main(["openclaw", "open-ui", "sbx-claw", "--json"])
 
         assert ret == 1
         message = json.loads(capsys.readouterr().out)["error"]["message"]
@@ -4881,7 +4890,7 @@ class TestOpenClawCommands:
         vm.run.side_effect = results
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw", "--json"])
+        ret = main(["openclaw", "open-ui", "sbx-claw", "--json"])
 
         assert ret == 1
         error = json.loads(capsys.readouterr().out)["error"]["message"]
@@ -4919,7 +4928,7 @@ class TestOpenClawCommands:
         vm.expose_local.return_value = 39876
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw", "--json"])
+        ret = main(["openclaw", "open-ui", "sbx-claw", "--json"])
 
         assert ret == 1
         assert "state corrupt" in json.loads(capsys.readouterr().out)["error"]["message"]
@@ -4952,7 +4961,7 @@ class TestOpenClawCommands:
         vm.expose_local.return_value = 39876
         mock_vm_from_id.return_value = vm
 
-        ret = main(["openclaw", "open", "sbx-claw"])
+        ret = main(["openclaw", "open-ui", "sbx-claw"])
 
         assert ret == 0
         assert "http://127.0.0.1:39876/#token=secret" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- hard-rename `smolvm openclaw open` to `smolvm openclaw open-ui` with no alias or compatibility fallback
- update the JSON command identifier and internal handler/type names
- update CLI tests, documentation, and the lower-level OpenClaw example
- verify the removed `open` command is rejected

## Testing
- `uv run pytest tests/cli/test_cli.py tests/windows/test_examples.py -q -k 'OpenClawCommands or openclaw'`
- `uv run ruff check examples/openclaw.py src/smolvm/cli/commands/app.py src/smolvm/cli/main.py tests/cli/test_cli.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CLI Changes**
  - Renamed the OpenClaw dashboard command from `open` to `open-ui`.
  - Updated command help, JSON output, examples, and usage guidance to reflect the new command name.
  - The former `open` subcommand is no longer accepted.

- **Documentation**
  - Updated the README, guides, and CLI reference with the `open-ui` command, including supported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->