### PR TITLE
Fix installer on macOS with no setup arguments

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,7 +154,11 @@ install_smolvm() {
 
 run_setup() {
     info "Running smolvm setup …"
-    smolvm setup --skip-deps "${SETUP_ARGS[@]}"
+    if ((${#SETUP_ARGS[@]})); then
+        smolvm setup --skip-deps "${SETUP_ARGS[@]}"
+    else
+        smolvm setup --skip-deps
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/host/test_setup_scripts.py
+++ b/tests/host/test_setup_scripts.py
@@ -185,6 +185,7 @@ def test_one_line_installer_keeps_custom_directory_for_doctor() -> None:
 
     assert "FIRECRACKER_DIR_ARG" in text
     assert 'export SMOLVM_FIRECRACKER_DIR="${FIRECRACKER_DIR_ARG}"' in text
+    assert "if ((${#SETUP_ARGS[@]})); then" in text
     assert 'smolvm setup --skip-deps "${SETUP_ARGS[@]}"' in text
 
 


### PR DESCRIPTION
## Summary

- avoid expanding an empty Bash array under 
- preserve forwarding of installer options to === SmolVM macOS setup (qemu backend) ===

✅ qemu-system binary found
✅ ssh found
✅ macOS setup complete
- add regression coverage for the safe conditional

## Testing

- 
- ============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/anurag/Developer/explore/2/SmolVM
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.4.0, anyio-4.15.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 12 items

tests/host/test_setup_scripts.py ............                            [100%]

============================== 12 passed in 4.56s ============================== (12 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installation reliability by preventing empty arguments from being passed during setup.
  - Custom setup options remain preserved when using the one-line installer.

- **Tests**
  - Added coverage to verify that custom setup options are retained and setup arguments are only forwarded when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->