### PR TITLE
Release v0.0.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.31"
+version = "0.0.32"
 description = "Open-source AI sandbox infrastructure with unified API for VMMs -- Firecracker, QEMU and libkrun."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release SmolVM 0.0.32 with the network-policy implementation and validation merged in #496 and #498. This PR only bumps the package version; runtime code and image pins are unchanged.

Validation: built sdist and wheel; installed the wheel in a clean environment; CLI reports 0.0.32; policy parsing smoke passes; 112 focused tests pass. All 54 published image manifest entries and both guest-agent pins match images-2026.09.07.0 release assets and checksum files. That image release passed smoke run 34124905498. Installed-wheel VM examples and the performance gate passed during #498 validation; there are no runtime changes since the measured wheel.

After approval and required CI, merge this PR, tag its main-branch commit v0.0.32, let the existing trusted-publishing workflow publish to PyPI, and publish the release notes below.

### Release notes

SmolVM now lets you turn outbound network access off or restrict it to specific IPv4 destinations while retaining command execution and file operations.

- Open access remains the default.
- Explicit off/restricted modes support Linux Firecracker NAT with vsock. Unsupported combinations fail early.
- Policy is enforced outside the guest and retained across restart and snapshot restore. Firewall-install failure prevents guest execution.
- Restricted mode allows IP addresses/ranges, not verified domain names. A DNS resolver must be explicitly allowed if needed.
- Open-mode p95 overhead measured below 1% in the completed performance comparison.

Upgrade with `uv tool upgrade smolvm` or `pip install --upgrade smolvm`. Existing running sandboxes receive corrected baseline rules when networking is reconciled or they restart; create a new sandbox to select a different policy. Legacy settings remain supported where documented; unenforced HTTP-method settings and unsupported restrictions now fail explicitly.

See the [networking guide](https://github.com/CelestoAI/SmolVM/blob/main/docs/guides/networking.md) and [validation report](https://github.com/CelestoAI/SmolVM/blob/main/docs/deep-dive/network-policy-release-validation.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version from 0.0.31 to 0.0.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->