### PR TITLE
Release v0.0.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.32"
+version = "0.0.33"
 description = "Open-source AI sandbox infrastructure with unified API for VMMs -- Firecracker, QEMU and libkrun."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- release the merged QEMU network controls as SmolVM v0.0.33
- keep the existing published guest-image and guest-agent pins unchanged

## Verification

- `uv run pytest`: 2,258 passed, 14 skipped, 49 deselected
- `uv run ruff check .`: passed
- built `smolvm-0.0.33-py3-none-any.whl`
- installed-wheel version and packaged setup-assets smoke: passed
- Linux QEMU TAP performance clearance passed on merged commit `3f9c215`

No production deployment or guest-image release is included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project version from 0.0.32 to 0.0.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->