### PR TITLE
Fix false QEMU version timeout after macOS setup

### DIFF
--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -46,6 +46,11 @@ from smolvm.utils import run_command, which
 
 DoctorStatus = Literal["pass", "warn", "fail"]
 
+# The first launch of a Homebrew QEMU binary on macOS can spend several
+# seconds in Gatekeeper and dynamic-library validation.  A five-second probe
+# can therefore fail even though QEMU is installed and usable.
+_QEMU_PROBE_TIMEOUT_SECONDS = 15
+
 
 @dataclass(frozen=True)
 class DoctorCheck:
@@ -117,13 +122,16 @@ def _check_qemu_version(qemu_path: Path) -> DoctorCheck:
             capture_output=True,
             text=True,
             check=False,
-            timeout=5,
+            timeout=_QEMU_PROBE_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired as exc:
+    except subprocess.TimeoutExpired:
         return DoctorCheck(
             name="qemu-version",
             status="warn",
-            detail=f"could not probe QEMU version: {exc}",
+            detail=(
+                "QEMU did not report its version within "
+                f"{_QEMU_PROBE_TIMEOUT_SECONDS} seconds. Run 'smolvm doctor' again."
+            ),
         )
     except (FileNotFoundError, OSError) as exc:
         return DoctorCheck(

--- a/tests/host/test_doctor.py
+++ b/tests/host/test_doctor.py
@@ -16,6 +16,7 @@
 
 import json
 import shlex
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -343,6 +344,21 @@ class TestDoctorQemu:
 
         assert checks["qemu-version"].status == "pass"
         assert checks["command:qemu-img"].status == "pass"
+        assert mock_run.call_args.kwargs["timeout"] == 15
+
+    @patch("smolvm.host.doctor.subprocess.run")
+    def test_qemu_version_timeout_has_actionable_warning(self, mock_run: MagicMock) -> None:
+        """A slow QEMU first launch should explain how to retry the check."""
+        from smolvm.host.doctor import _check_qemu_version
+
+        mock_run.side_effect = subprocess.TimeoutExpired("qemu-system-aarch64", 15)
+
+        check = _check_qemu_version(Path("/opt/homebrew/bin/qemu-system-aarch64"))
+
+        assert check.status == "warn"
+        assert check.detail == (
+            "QEMU did not report its version within 15 seconds. Run 'smolvm doctor' again."
+        )
 
     @patch("smolvm.host.doctor.platform.system", return_value="Linux")
     @patch("smolvm.host.doctor.subprocess.run")


### PR DESCRIPTION
## Summary

- allow up to 15 seconds for the QEMU version probe so macOS first-launch validation does not cause a false warning
- replace the raw timeout exception with an actionable message suggesting `smolvm doctor` be run again
- add regression coverage for the timeout value and warning text

## Testing

- `uv run pytest tests/host/test_doctor.py -q` (17 passed)
- `uv run ruff check src/smolvm/host/doctor.py tests/host/test_doctor.py`
- `uv run ruff format --check src/smolvm/host/doctor.py tests/host/test_doctor.py`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved QEMU version detection on macOS by allowing additional time for first-launch system validation.
  - Added a clearer warning when the QEMU check times out, including the timeout duration and guidance to rerun `smolvm doctor`.

- **Tests**
  - Added coverage for timeout warnings and the updated QEMU probe timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->