### PR TITLE
Release v0.0.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.33"
+version = "0.0.34"
 description = "Open-source AI sandbox infrastructure with unified API for VMMs -- Firecracker, QEMU and libkrun."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- release the merged TypeScript SDK session server as SmolVM v0.0.34
- make the existing official installer resolve the new server extra from PyPI
- keep the published guest-image and guest-agent pins unchanged

## Verification

- `uv run pytest`: 2,351 passed, 8 skipped, 49 deselected
- `uv run ruff check .`: passed
- built `smolvm-0.0.34-py3-none-any.whl` and source distribution
- installed isolated `smolvm[server]` wheel smoke: passed
- packed TypeScript SDK tests: 16 passed; typecheck, contracts, ESM/CommonJS build, examples passed
- installed wheel + packed SDK real QEMU smoke: `HELLO` and sandbox cleanup passed

No guest-image or guest-agent release is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.0.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->