### PR TITLE
Fix TypeScript prerelease repository targeting

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Verify tag and attach checksummed package
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           archive="$(find . -name 'celestoai-smolvm-*.tgz' -print -quit)"
           version="$(tar -xOf "$archive" package/package.json | node -e "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>console.log(JSON.parse(s).version))")"


### PR DESCRIPTION
## Summary

- provide `GH_REPO` to the release job so GitHub CLI can create a release without a checkout
- preserve the existing tag, package-version, and checksum verification

## Validation

- `git diff --check`
- `npm --prefix ts test`
- verified the workflow artifact reports `@celestoai/smolvm@0.1.0-preview.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved prerelease workflow configuration to ensure release commands target the current repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->